### PR TITLE
2023-07-03 :: 댓글 작성 보완 및 기타 이슈사항 수정

### DIFF
--- a/src/main/commonsComponents/functional/index.ts
+++ b/src/main/commonsComponents/functional/index.ts
@@ -140,6 +140,26 @@ const getUserIp = async () => {
   return ip;
 };
 
+// id 값을 이용해 해당 document 위치로 이동하기
+const moveDocument = (id: string, bonus?: number | 0) => {
+  const doc = document.getElementById(id);
+
+  if (doc) {
+    const { top } = doc.getBoundingClientRect();
+
+    // 해당 document의 위치로 이동
+    const destination =
+      top +
+      (window.pageYOffset || document.documentElement.scrollTop) -
+      50 +
+      (bonus || 0);
+
+    window.scrollTo({
+      top: destination,
+    });
+  }
+};
+
 export {
   removeTag,
   getDateForm,
@@ -147,4 +167,5 @@ export {
   getHashPassword,
   getUuid,
   getUserIp,
+  moveDocument,
 };

--- a/src/main/commonsComponents/units/index/index.container.tsx
+++ b/src/main/commonsComponents/units/index/index.container.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect } from "react";
 
-// import { _CloseButton, _Button } from "mcm-js-commons";
 import { IndexIPropsTypes, IndexPagePropsTypes } from "./index.type";
+import { moveDocument } from "../../functional";
 
 import _IndexUIForm from "./index.presenter";
 
 // 목차 렌더 페이지
 let deboucing: ReturnType<typeof setTimeout> | number;
+// 해당 목차가 아직 렌더되지 않았을 경우 해당 목차가 렌더될 때까지 재요청하는 변수
+let infiniteRequestDocument: number | ReturnType<typeof setInterval>;
 export default function _IndexForm(
   props: IndexIPropsTypes & IndexPagePropsTypes
 ) {
@@ -54,19 +56,21 @@ export default function _IndexForm(
 
   // 해당 목차로 이동하기
   const moveIndex = (id: string) => {
-    const documents = document.getElementById(id);
+    // 해당 목차 위치로 스크롤 이동
+    moveDocument(id);
+    clearInterval(infiniteRequestDocument);
 
-    if (documents) {
-      const { top } = documents.getBoundingClientRect();
+    // 댓글 목차를 선택했을 경우
+    if (id === "comments-form") {
+      // 댓글 목차가 렌더 될때까지 무한하게 스크롤 이동
+      infiniteRequestDocument = setInterval(() => {
+        const doc = document.getElementsByClassName("comments-subTitle");
 
-      // 해당 목차의 시작 위치 구하기
-      const destination =
-        top + (window.pageYOffset || document.documentElement.scrollTop) - 50;
-
-      window.scrollTo({
-        top: destination,
-        // behavior: "smooth",
-      });
+        if (doc) {
+          moveDocument(id);
+          clearInterval(infiniteRequestDocument);
+        }
+      }, 200);
     }
   };
 

--- a/src/main/commonsComponents/units/index/index.data.tsx
+++ b/src/main/commonsComponents/units/index/index.data.tsx
@@ -7,7 +7,7 @@ export const indexOptionalDataList: Array<{
   clickEvent?: string; // 버튼 클릭 함수 이름
 }> = [
   {
-    tooltipText: ["목차 고정", "목차 가리기"],
+    tooltipText: ["목차 고정", "목차 고정 해제"],
     target: "fix",
     isClose: false,
     emoji: "📌",
@@ -20,5 +20,5 @@ export const indexOptionalDataList: Array<{
     emoji: ["↙", "↗"],
     clickEvent: "toggleMinimum",
   },
-  { tooltipText: "목차 닫기", target: "close", isClose: true },
+  { tooltipText: "목차 숨기기", target: "close", isClose: true },
 ];

--- a/src/main/commonsComponents/units/index/index.presenter.tsx
+++ b/src/main/commonsComponents/units/index/index.presenter.tsx
@@ -3,6 +3,7 @@ import {
   IndexListWrapper,
   Items,
   OptionWrapper,
+  OpenIndexButton,
 } from "./index.styles";
 
 import { _Button, _CloseButton } from "mcm-js-commons";
@@ -19,98 +20,73 @@ import {
 
 type allTypes = IndexIPropsTypes & IndexUIPropsTypes & IndexPagePropsTypes;
 export default function _IndexUIForm(props: { [key: string]: any } & allTypes) {
-  const { indexList, current, moveIndex, closeIndex, isMinimum } = props;
+  const { indexList, current, moveIndex, toggleIndex, isMinimum, show } = props;
 
   return (
     <Items className="mcm-index-items">
-      <OptionWrapper className="mcm-index-option-wrapper">
-        {indexOptionalDataList.map((info, idx) => (
-          <Tooltip
-            key={`index-option-list-${info.target}-${idx}`}
-            useShowAnimation
-            tooltipText={
-              Array.isArray(info.tooltipText)
-                ? info.tooltipText[Number(props[info.target])]
-                : info.tooltipText
-            }
-          >
-            {info.isClose ? (
-              <_CloseButton
-                onClickEvent={closeIndex}
-                className="mcm-index-close-button"
-              />
-            ) : (
-              <_Button
-                className={`mcm-index-optional-button mcm-index-${
-                  info.target
-                }-button ${props[info.target] ? "on" : "off"}`}
-                onClickEvent={() =>
-                  (info.clickEvent && props[info.clickEvent]()) || undefined
+      {show ? (
+        <>
+          <OptionWrapper className="mcm-index-option-wrapper">
+            {indexOptionalDataList.map((info, idx) => (
+              <Tooltip
+                key={`index-option-list-${info.target}-${idx}`}
+                useShowAnimation
+                tooltipText={
+                  Array.isArray(info.tooltipText)
+                    ? info.tooltipText[Number(props[info.target])]
+                    : info.tooltipText
                 }
               >
-                {Array.isArray(info.emoji)
-                  ? info.emoji[Number(props[info.target])]
-                  : info.emoji}
-              </_Button>
+                {info.isClose ? (
+                  <_CloseButton
+                    onClickEvent={() => toggleIndex(false)}
+                    className="mcm-index-close-button"
+                  />
+                ) : (
+                  <_Button
+                    className={`mcm-index-optional-button mcm-index-${
+                      info.target
+                    }-button ${props[info.target] ? "on" : "off"}`}
+                    onClickEvent={() =>
+                      (info.clickEvent && props[info.clickEvent]()) || undefined
+                    }
+                  >
+                    {Array.isArray(info.emoji)
+                      ? info.emoji[Number(props[info.target])]
+                      : info.emoji}
+                  </_Button>
+                )}
+              </Tooltip>
+            ))}
+          </OptionWrapper>
+          <IndexListWrapper>
+            {!isMinimum ? (
+              indexList.map((list, idx) => (
+                <IndexList key={getUuid()} isSelected={current === idx}>
+                  <_Button
+                    onClickEvent={() => current !== idx && moveIndex(list.id)}
+                    className="index-button"
+                  >
+                    {list.title}
+                  </_Button>
+                </IndexList>
+              ))
+            ) : (
+              <IndexList isSelected={true}>
+                <_Button onClickEvent={() => {}} className="index-button">
+                  {indexList[current].title}
+                </_Button>
+              </IndexList>
             )}
-          </Tooltip>
-        ))}
-
-        {/* <Tooltip
-          tooltipText={fix ? "목차 가리기" : "목차 고정"}
-          useShowAnimation
-          position={{ top: "-50px" }}
-        >
-          <FixButton
-            onClickEvent={toggleFix}
-            fix={fix}
-            className="mcm-index-fix-button"
-          >
-            📌
-          </FixButton>
+          </IndexListWrapper>
+        </>
+      ) : (
+        <Tooltip tooltipText="목차 보이기" useShowAnimation>
+          <OpenIndexButton onClickEvent={() => toggleIndex(true)}>
+            📋
+          </OpenIndexButton>
         </Tooltip>
-
-        <Tooltip
-          tooltipText={isMinimum ? "최대화" : "최소화"}
-          useShowAnimation
-          position={{ top: "-50px" }}
-        >
-          <ResizeButton onClickEvent={toggleMinimum}>
-            {!isMinimum ? "↙" : "↗"}
-          </ResizeButton>
-        </Tooltip>
-
-        <Tooltip
-          tooltipText="목차 닫기"
-          useShowAnimation
-          position={{ top: "-50px" }}
-        >
-          <_CloseButton
-            onClickEvent={closeIndex}
-            className="mcm-index-close-button"
-          />
-        </Tooltip> */}
-      </OptionWrapper>
-      <IndexListWrapper>
-        {!isMinimum ? (
-          indexList.map((list, idx) => (
-            <IndexList key={getUuid()} isSelected={current === idx}>
-              <_Button
-                onClickEvent={() => current !== idx && moveIndex(list.id)}
-                className="index-button"
-              >
-                {list.title}
-              </_Button>
-            </IndexList>
-          ))
-        ) : (
-          <IndexList isSelected={true}>
-            <_Button onClickEvent={() => {}} className="index-button">
-              {indexList[current].title}
-            </_Button>
-          </IndexList>
-        )}
-      </IndexListWrapper>
+      )}
     </Items>
   );
 }

--- a/src/main/commonsComponents/units/index/index.render.tsx
+++ b/src/main/commonsComponents/units/index/index.render.tsx
@@ -17,9 +17,10 @@ export default function IndexRenderPage(props: IndexIPropsTypes) {
   // 최소화 여부
   const [isMinimum, setIsMinimum] = useState(false);
 
-  // 목차창 닫기
-  const closeIndex = () => {
-    setShow(false);
+  // 목차창 on/off
+  const toggleIndex = (bool?: boolean) => {
+    setShow((prev) => (bool ? bool : !prev));
+    setFix(true);
   };
 
   // 고정 toggle
@@ -34,16 +35,15 @@ export default function IndexRenderPage(props: IndexIPropsTypes) {
 
   // 페이지 렌더 여부 확인 및 최종 렌더하기
   const renderIndexPage = () => {
-    if (!show) return <></>;
-
     let node = (
       <_IndexForm
         {...props}
-        closeIndex={closeIndex}
+        toggleIndex={toggleIndex}
         fix={fix}
         toggleFix={toggleFix}
         isMinimum={isMinimum}
         toggleMinimum={toggleMinimum}
+        show={show}
       />
     );
     let errorMessage;
@@ -94,6 +94,7 @@ export default function IndexRenderPage(props: IndexIPropsTypes) {
         className="mcm-index-wrapper"
         fix={offFixed ? false : fix}
         isMinimum={isMinimum}
+        show={show}
       >
         {node}
       </Wrapper>

--- a/src/main/commonsComponents/units/index/index.styles.ts
+++ b/src/main/commonsComponents/units/index/index.styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-// import { _Button } from "mcm-js-commons";
+import { _Button } from "mcm-js-commons";
 
 import { breakPoints } from "mcm-js-commons/dist/responsive";
 
@@ -7,6 +7,7 @@ interface StyleTypes {
   isSelected?: boolean;
   fix?: boolean;
   isMinimum?: boolean;
+  show?: boolean;
 }
 
 export const Wrapper = styled.div`
@@ -32,7 +33,13 @@ export const Wrapper = styled.div`
       opacity: 1,
     }}
 
-  ${(props) => props.isMinimum && {}}
+  ${(props) =>
+    !props.show && {
+      padding: "0px",
+      width: "auto",
+      borderRadius: "100%",
+      border: "solid 2px gray",
+    }}
 
   .error-message {
     line-height: 30px;
@@ -128,4 +135,8 @@ export const OptionWrapper = styled.div`
       color: transparent;
     }
   }
+`;
+
+export const OpenIndexButton = styled(_Button)`
+  padding: 10px 12px;
 `;

--- a/src/main/commonsComponents/units/index/index.type.ts
+++ b/src/main/commonsComponents/units/index/index.type.ts
@@ -6,11 +6,12 @@ export interface IndexIPropsTypes {
 
 // index.container Props type
 export interface IndexPagePropsTypes {
-  closeIndex: () => void; // 목차창 닫기
+  toggleIndex: (bool: boolean) => void; // 목차창 토글
   toggleFix: () => void; // 고정 toggle
   toggleMinimum: () => void; // 최소화 toggle
   fix: boolean;
   isMinimum: boolean;
+  show: boolean;
 }
 
 // index.presenter Props type

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/list.styles.ts
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/list.styles.ts
@@ -165,7 +165,12 @@ export const SelectWrapper = styled.div`
     }}
 
   .mcm-unit-select {
-    top: 30px;
+    top: -90px;
+    flex-direction: column-reverse;
+
+    .mcm-close-button-unit {
+      transform: translate3d(5px, 5px, 0px);
+    }
   }
 `;
 

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.container.tsx
@@ -119,6 +119,10 @@ export default function ContentsSelectFunctionalPage({
           border: `double 5px #${isSuccess ? "19a7ce" : "aa5656"}`,
         },
       },
+      mobileModalSize: {
+        width: "100%",
+        height: "10%",
+      },
       onCloseModal: _afterCloseEvent,
     });
   };

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
@@ -110,6 +110,8 @@ export default function CommentsWritePage({
         }, 100);
     };
 
+    // 모달의 height
+    let height = "90px";
     // 에러모달 띄우기
     const openErrorModal = ({
       message, // 에러메세지
@@ -138,10 +140,11 @@ export default function CommentsWritePage({
         showBGAnimation: true,
         showModalOpenAnimation: true,
         modalSize: {
-          height: "200px",
+          height: "160px",
         },
         mobileModalSize: {
-          height: "30%",
+          width: "95%",
+          height: height,
         },
         onCloseModal: () => Modal.close({ id: "writing-modal" }),
         onAfterCloseEvent: afterEvent,
@@ -157,42 +160,22 @@ export default function CommentsWritePage({
         message: "댓글을 등록하고 있습니다. <br /> 잠시만 기다려주세요.",
       });
     } else {
-      if (info.category === "all") {
-        // 카테고리를 선택하지 않은 경우
-        errorMessage = "카테고리를 선택해주세요.";
-      } else {
-        // 카테고리를 선택한 경우
-        if (!info.contents) {
-          // 댓글 내용을 입력하지 않은 경우
-          errorMessage = "댓글 내용을 작성해주세요.";
-          errorType = "contents";
+      height = "10%";
+      // 댓글 작성시 누락된 부분 체크하기
+      const errorCheck = checkWriteAble();
 
-          // if (contentsRef.current) afterEvent = ;
-        } else if (!info.password) {
-          // 비밀번호를 입력하지 않은 경우
-          errorMessage = "비밀번호를 입력해주세요.";
-          errorType = "password";
-        } else if (info.category === "review") {
-          if (!info.rating) {
-            // 평점을 선택하지 않을 경우
-            errorMessage = "평점을 선택해주세요.";
-          }
-        } else if (info.category === "bug") {
-          if (!info.bugLevel) {
-            // 이슈 중요도를 선택하지 않을 경우
-            errorMessage = "이슈 중요도를 선택해주세요.";
-          }
-        } else if (!info.agreeProvacy) {
-          // 개인정보 수집에 동의하지 않을 경우
-          errorMessage = "개인정보 (IP) 수집에 동의해주세요.";
-          errorType = "privacy";
-        }
+      // 누락된 부분 저장
+      if (!errorCheck.able) {
+        errorMessage = errorCheck.error.message;
+        errorType = errorCheck.error.type;
       }
     }
 
     if (errorMessage) {
       openErrorModal({ message: errorMessage });
     } else {
+      height = "90px";
+
       // 줄바꿈 처리하기
       info.contents = changeMultipleLine(info.contents.trim());
 
@@ -244,6 +227,57 @@ export default function CommentsWritePage({
     }
   };
 
+  // 댓글 작성 가능 여부 확인하기
+  const checkWriteAble = () => {
+    // able : 작성 가능 여부 (true일 경우 작성 가능)
+    // message : 에러 메세지
+    // type : 에러 타입
+    let result = { able: false, error: { message: "", type: "" } };
+
+    if (info.category === "all") {
+      // 카테고리가 선택되지 않았을 경우
+      result.error.message = "카테고리를 선택해주세요.";
+      result.error.type = "category";
+
+      //
+    } else if (!info.contents) {
+      // 댓글 내용이 입력되지 않을 경우
+      result.error.message = "댓글 내용을 작성해주세요.";
+      result.error.type = "contents";
+
+      //
+    } else if (!info.password) {
+      // 비밀번호를 입력하지 않을 경우
+      result.error.message = "비밀번호를 입력해주세요.";
+      result.error.type = "password";
+
+      //
+    } else if (!info.agreeProvacy) {
+      // ip 수집에 동의하지 않을 경우
+      result.error.message = "개인정보 (IP) 수집에 동의해주세요.";
+      result.error.type = "privacy";
+
+      //
+    } else if (info.category === "review") {
+      // 카테고리가 리뷰일 때
+      if (!info.rating) {
+        // 평점을 선택하지 않을 경우
+        result.error.message = "평점을 선택해주세요.";
+        result.error.type = "rating";
+      }
+    } else if (info.category === "bug") {
+      // 카테고리가 버그일 때
+      if (!info.bugLevel) {
+        // 이슈 중요도를 선택하지 않을 경우
+        result.error.message = "이슈 중요도를 선택해주세요.";
+        result.error.type = "bug-level";
+      }
+    }
+
+    if (!result.error.message && !result.error.type) result.able = true;
+    return result;
+  };
+
   return (
     <CommentsWriteUIPage
       categoryList={categoryList}
@@ -254,6 +288,7 @@ export default function CommentsWritePage({
       contentsRef={contentsRef}
       passwordRef={passwordRef}
       openPrivacy={openPrivacy}
+      checkWriteAble={checkWriteAble}
     />
   );
 }

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.presenter.tsx
@@ -5,6 +5,7 @@ import {
   SelectCategory,
   WriteWrapper,
   SubmitWrapper,
+  WriteButton,
 } from "./comments.write.styles";
 
 import { _Input, _Button } from "mcm-js-commons";
@@ -40,7 +41,9 @@ export default function CommentsWriteUIPage({
   contentsRef,
   passwordRef,
   openPrivacy,
+  checkWriteAble,
 }: IPropsTypes) {
+  console.log(checkWriteAble());
   return (
     <Form onSubmit={write}>
       <fieldset>
@@ -126,9 +129,13 @@ ${info.category && defaultPlace}`}
           info={info}
           openPrivacy={openPrivacy}
         />
-        <_Button onClickEvent={write} className="write-comments-button">
+        <WriteButton
+          onClickEvent={write}
+          className="write-comments-button"
+          isAble={checkWriteAble().able}
+        >
           📝 댓글 등록
-        </_Button>
+        </WriteButton>
       </SubmitWrapper>
     </Form>
   );

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.styles.ts
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.styles.ts
@@ -2,12 +2,14 @@ import { CSSProperties } from "react";
 import styled from "@emotion/styled";
 
 import { breakPoints } from "mcm-js-commons/dist/responsive";
+import { _Button } from "mcm-js-commons";
 
 interface StyleTypes {
   category?: string;
   isRating?: boolean;
   show?: boolean;
   checked?: boolean;
+  isAble?: boolean;
 }
 
 export const Form = styled.form`
@@ -162,6 +164,13 @@ export const Message = styled.div`
     align-items: center;
     text-align: center;
   }
+
+  @media ${breakPoints.mobileLarge} {
+    .message {
+      font-size: 18px;
+      white-space: pre;
+    }
+  }
 `;
 
 export const SubmitWrapper = styled.div`
@@ -173,18 +182,35 @@ export const SubmitWrapper = styled.div`
     flex-direction: column;
     align-items: flex-start;
     gap: 12px 0px;
-
-    .write-comments-button {
-      width: 100%;
-      padding: 8px 0px;
-      border: solid 1px gray;
-      border-radius: 5px;
-      font-size: 14px;
-    }
   }
 `;
 
 export const BugStatusWrapper = styled.div`
   display: flex;
   margin: 10px 0px;
+`;
+
+export const WriteButton = styled(_Button)`
+  font-weight: 700;
+
+  // 누락된 부분으로 등록이 불가능한 상태
+  ${(props: StyleTypes) =>
+    !props.isAble && {
+      cursor: "not-allowed",
+      color: "#666666",
+      fontWeight: 400,
+    }}
+
+  @media ${breakPoints.mobileLarge} {
+    width: 100%;
+    padding: 8px 0px;
+    border: solid 1px #999999;
+    border-radius: 5px;
+    font-size: 14px;
+
+    ${(props) =>
+      props.isAble && {
+        borderColor: "black",
+      }}
+  }
 `;

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.types.ts
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.types.ts
@@ -56,4 +56,8 @@ export interface IPropsTypes {
   contentsRef: MutableRefObject<HTMLTextAreaElement>;
   passwordRef: MutableRefObject<HTMLInputElement>;
   openPrivacy: boolean;
+  checkWriteAble: () => {
+    able: boolean;
+    error: { message: string; type: string };
+  };
 }

--- a/src/main/commonsComponents/units/template/form/comments/write/privacy/privacy.styles.ts
+++ b/src/main/commonsComponents/units/template/form/comments/write/privacy/privacy.styles.ts
@@ -13,7 +13,7 @@ export const AgreeUserPrivacyWrapper = styled.div`
   #privacy-label {
     font-size: 14px;
     cursor: pointer;
-    color: gray;
+    color: #666666;
     width: 194px;
   }
 
@@ -23,7 +23,7 @@ export const AgreeUserPrivacyWrapper = styled.div`
   }
 
   .privacy-notice {
-    color: gray;
+    color: #666666;
   }
 
   @media ${breakPoints.mobileLarge} {

--- a/src/main/commonsComponents/units/template/form/howUse/fixed/fixed.container.tsx
+++ b/src/main/commonsComponents/units/template/form/howUse/fixed/fixed.container.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, MutableRefObject, useEffect } from "react";
 
 import ExampleFixedUIPage from "./fixed.presenter";
 import { ExampleCodeListTypes } from "src/main/mainComponents/modules/modal/example/modal.example.code.data";
+import { moveDocument } from "src/main/commonsComponents/functional";
 
 let eventStart: boolean = false; // 스크롤 이벤트 시작여부
 let itemsHeight: number = 0; // tap items 태그의 높이값 설정
@@ -47,10 +48,6 @@ export default function ExampleFixedPage({
         // functional의 상대적 위치값 가져오기
         const { top } = _wrapperRef.current.getBoundingClientRect();
 
-        // const startFixedPoint = // Fixed 시작 위치
-        //   scrollTop +
-        //   (_wrapperRef.current?.offsetTop - scrollTop) +
-        //   _wrapperRef.current?.clientHeight;
         setTempVers(vers);
 
         const endFixedPoint = // Fixed 종료 위치

--- a/src/main/commonsComponents/units/template/form/howUse/fixed/fixed.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/howUse/fixed/fixed.presenter.tsx
@@ -32,13 +32,16 @@ export default function ExampleFixedUIPage({
       <TapItems isFixed={fixed} itemsHeight={itemsHeight}>
         <TapListPage tapList={codeInfo.title || []} />
       </TapItems>
+
       <FixedTap ref={_fixedRef}>
-        <TapListPage
-          tapList={codeInfo.title || []}
-          changeTempVers={changeTempVers}
-          isFixedMode={fixed}
-          fixed={fixed}
-        />
+        {fixed && (
+          <TapListPage
+            tapList={codeInfo.title || []}
+            changeTempVers={changeTempVers}
+            isFixedMode={fixed}
+            fixed={fixed}
+          />
+        )}
       </FixedTap>
     </TapWrapper>
   );

--- a/src/main/commonsComponents/units/template/form/howUse/fixed/fixed.styles.ts
+++ b/src/main/commonsComponents/units/template/form/howUse/fixed/fixed.styles.ts
@@ -31,6 +31,7 @@ export const TapWrapper = styled.div`
 
   .widen {
     width: ${(props) => (props.allLength || 1) * 150 + "px"};
+    height: 60px;
   }
 
   .fixed-mode {
@@ -108,7 +109,7 @@ export const FixedTap = styled.div`
   opacity: 0;
   position: fixed;
   width: 60px;
-  height: 60px;
+  height: 0px;
   left: 50%;
   right: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
1. 기존 댓글 작성시에 누락된 부분이 있을 때 출력되는 에러메세지를 하나의 함수 안에서 미리 체크하는 방식으로 변경, 이 함수를 이용해 등록 버튼의 비활성화 여부 및 스타일을 지정할 수 있도록 변경
2. 목차 페이지에서 해당 목차를 선택했을 때 스크롤이 이동되는 방식을 공통 함수로 전환
3. 기존의 목차 페이지에서 댓글을 클릭했을 때 댓글이 렌더되지 않았을 경우 스크롤이 정상적으로 댓글 페이지로 이동하지 않는 이슈 수정
  -> setInterval을 이용하여 0.2초 간격으로 댓글 페이지의 렌더를 확인한 후 스크롤 최종 이동
4. 목차 닫기를 클릭했을 경우 아예 목차 자체가 닫히는 건 부자연스럽다 판단하여 목차 닫기를 클릭할 경우 목차 이모지로 변경하여 해당 이모지를 클릭했을 때 목차를 다시 열 수 있도록 변경
5. 목차 닫기의 Tooltip 메세지는 목차 숨기기 / 목차 보이기로 변경
6. 모바일 환경에서 댓글 수정 및 삭제에 대한 에러 메세지 창이 비정상적으로 크게 나오는 이슈 수정 완료