### PR TITLE
2023-07-09 :: 관리자 페이지 이동 이슈 해결 및 관리자 페이지 및 유저 페이지 스타일 분할 설정 완료

### DIFF
--- a/src/main/commonsComponents/functional/index.ts
+++ b/src/main/commonsComponents/functional/index.ts
@@ -1,3 +1,5 @@
+import { useRouter } from "next/router";
+
 // 태그 제거하기
 const removeTag = (str: string) => {
   return str
@@ -103,9 +105,7 @@ const getHashText = async (
     str = data.join(" + ");
   }
   // salt 적용하기
-  str += salt
-    ? salt
-    : process.env.NEXT_PUBLIC_SALT || "mcm-sejun3278-Salt-data-0515";
+  str += salt || process.env.NEXT_PUBLIC_SALT || "mcm-sejun3278-Salt-data-0515";
 
   return createHash("sha256").update(str).digest("hex");
 };
@@ -170,6 +170,14 @@ const moveDocument = (id: string, bonus?: number | 0) => {
       top: destination,
     });
   }
+};
+
+// 현재 페이지가 관리자 페이지인지 검증
+const getIsAdminPage = () => {
+  const router = useRouter();
+
+  const pathName = router.pathname;
+  return pathName.includes("admin") && pathName.split("/")[1] === "admin";
 };
 
 export {

--- a/src/main/commonsComponents/hooks/commonsHooks.tsx
+++ b/src/main/commonsComponents/hooks/commonsHooks.tsx
@@ -58,6 +58,12 @@ export default function CommonsHooksComponents() {
     }, "");
   };
 
+  // 현재 페이지가 관리자 페이지인지 검증
+  const getIsAdminPage = () => {
+    const pathName = router.pathname;
+    return pathName.includes("admin") && pathName.split("/")[1] === "admin";
+  };
+
   return {
     componentRender,
     getAllComponentsClassName,
@@ -65,5 +71,6 @@ export default function CommonsHooksComponents() {
     getModuleNamewithJadenCase,
     getAllExampleComponentLength,
     getOriginTemplate,
+    getIsAdminPage,
   };
 }

--- a/src/main/commonsComponents/layout/header/index.tsx
+++ b/src/main/commonsComponents/layout/header/index.tsx
@@ -3,9 +3,9 @@ import styled from "@emotion/styled";
 import { _Image, _Link } from "mcm-js-commons";
 import { breakPoints } from "mcm-js-commons/dist/responsive";
 
-export default function LayoutHeadPage() {
+export default function LayoutHeadPage({ isAdmin }: { isAdmin?: boolean }) {
   return (
-    <HeaderWrapper className="layout-header-wrapper">
+    <HeaderWrapper className="layout-header-wrapper" isAdmin={isAdmin}>
       <_Link href="/" className="layout-header-link">
         <_Image
           src="/images/commons/logo/MCM_white_logo.png"
@@ -22,6 +22,11 @@ const HeaderWrapper = styled.header`
   justify-content: center;
   align-items: center;
   height: 220px;
+
+  ${(props: { isAdmin?: boolean }) =>
+    props.isAdmin && {
+      backgroundColor: "#525FE1",
+    }}
 
   .layout-header-link {
     height: 100%;

--- a/src/main/commonsComponents/layout/index.tsx
+++ b/src/main/commonsComponents/layout/index.tsx
@@ -14,27 +14,31 @@ interface IProps {
 }
 
 export default function LayoutPage(props: IProps) {
-  const { getRouter, getModuleNamewithJadenCase } = CommonsHooksComponents();
+  const { getRouter, getModuleNamewithJadenCase, getIsAdminPage } =
+    CommonsHooksComponents();
   const [module, setModule] = useRecoilState(moduleState);
   const [adminLogin] = useRecoilState(adminLoginState);
 
   const router = getRouter();
-  // 현재가 관리자 페이지인지?
-  const isAdmin = router.pathname.split("/")[1] === "admin";
 
   useEffect(() => {
     // 현재 선택한 모듈 저장하기
     setModule(getModuleNamewithJadenCase());
   }, [router]);
 
+  // 현재가 관리자 페이지인지?
+  const isAdmin = getIsAdminPage();
+
   let navRenderCondition = !isAdmin;
   if (isAdmin && adminLogin) navRenderCondition = true;
 
   return (
     <LayoutWrapper className="layout-home-wrapper">
-      <LayoutHeadPage />
+      <LayoutHeadPage isAdmin={isAdmin} />
       <LayoutContentsWrapper>
-        {navRenderCondition && <LayoutNavPage module={module} />}
+        {navRenderCondition && (
+          <LayoutNavPage module={module} isAdmin={isAdmin} />
+        )}
         {props.children}
       </LayoutContentsWrapper>
     </LayoutWrapper>

--- a/src/main/commonsComponents/layout/nav/index.tsx
+++ b/src/main/commonsComponents/layout/nav/index.tsx
@@ -15,27 +15,22 @@ import { _Link } from "mcm-js-commons";
 export default function LayoutNavPage({
   isMobileTap,
   module,
+  isAdmin,
 }: {
   isMobileTap?: boolean;
   module: string;
+  isAdmin?: boolean;
 }) {
   // 모듈 검색어
   const [search, setSearch] = useState<string>("");
   // 렌더 여부
   const [render, setRender] = useState<boolean>(false);
-  // 현재 페이지가 관리자 페이지인지 검증
-  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     if (!module) setSearch("");
 
     setRender(true);
   }, [module]);
-
-  // 관리자 페이지 검증하기
-  useEffect(() => {
-    setIsAdmin(location.pathname.split("/")[1] === "admin");
-  });
 
   const onChangeSearch = (text: string) => {
     setSearch(text);

--- a/src/main/commonsComponents/layout/nav/list/index.tsx
+++ b/src/main/commonsComponents/layout/nav/list/index.tsx
@@ -3,6 +3,7 @@ import { breakPoints } from "mcm-js-commons/dist/responsive";
 
 import { NavListTypes } from "../nav.data";
 import { _Link, _PText, _SpanTextWithHtml } from "mcm-js-commons";
+import { CSSProperties } from "react";
 
 export default function NavListPage({
   list,
@@ -88,14 +89,25 @@ export const ListWrapper = styled.ul`
     .mcm-link-unit {
       display: block;
 
-      ${(props: StyleTypes) =>
-        props.isSelect && {
-          padding: "0.5rem",
-          borderRadius: "10px",
-          backgroundColor: "#aa5656",
-          color: "white",
-          width: "calc(100% + 50px)",
-        }}
+      ${(props) => {
+        let styles: CSSProperties & { [key: string]: string } = {};
+
+        if (props.isSelect) {
+          styles = {
+            padding: "0.5rem",
+            borderRadius: "10px",
+            backgroundColor: "#aa5656",
+            color: "white",
+            width: "calc(100% + 50px)",
+          };
+
+          if (props.isAdmin) {
+            styles.backgroundColor = "#525FE1";
+          }
+        }
+
+        return styles;
+      }}
     }
   }
 

--- a/src/main/commonsComponents/layout/nav/nav.styles.ts
+++ b/src/main/commonsComponents/layout/nav/nav.styles.ts
@@ -23,6 +23,7 @@ export const LayoutNavWrapper = styled.nav`
   ${(props) =>
     props.isAdmin && {
       padding: "1rem",
+      borderRightColor: "#525FE1",
     }}
 
   @media ${breakPoints.mobileLarge} {

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.container.tsx
@@ -6,7 +6,7 @@ import { FormEvent, MutableRefObject, useEffect, useRef } from "react";
 import { Modal } from "mcm-js";
 import { _SpanText } from "mcm-js-commons";
 
-import { getServerTime } from "src/commons/libraries/firebase";
+import { getServerTime, db } from "src/commons/libraries/firebase";
 import { WriteInfoTypes } from "../../../../write/comments.write.types";
 import { InfoTypes } from "../../../../comments.types";
 
@@ -20,7 +20,6 @@ import {
   ListContentsSelectType,
   ContentsSelectTypeName,
 } from "../../list.data";
-import { db } from "src/commons/libraries/firebase";
 
 let password = ""; // 패스워드 저장
 let _contents = ""; // 댓글 내용 저장
@@ -38,7 +37,7 @@ export default function ContentsSelectFunctionalPage({
   info: InfoTypes;
   type: ListContentsSelectType;
   modifyComments: (comment: InfoTypes, isDelete?: boolean) => Promise<boolean>;
-  adminLogin: boolean;
+  adminLogin: boolean | null;
 }) {
   _contents = info.contents;
   rating = info.rating;

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.presenter.tsx
@@ -37,7 +37,7 @@ export default function ContentsSelectFunctionalUIPage({
     type: "contents" | "password" | "rating" | "bugLevel"
   ) => void;
   confirm: (e?: FormEvent) => void;
-  adminLogin: boolean;
+  adminLogin: boolean | null;
 }) {
   return (
     <Form onSubmit={confirm}>
@@ -81,7 +81,7 @@ export default function ContentsSelectFunctionalUIPage({
             onChangeEvent={(text) => changeData(text, "password")}
             maxLength={20}
             inputRef={passwordRef}
-            readOnly={adminLogin}
+            readOnly={adminLogin || false}
           />
         )}
         <ConfirmButtonWrapper>

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.styles.ts
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.styles.ts
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { _Input } from "mcm-js-commons";
 import { breakPoints } from "mcm-js-commons/dist/responsive";
 
 interface StyleTypes {

--- a/src/main/commonsComponents/units/template/form/comments/list/label/index.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/label/index.tsx
@@ -24,7 +24,7 @@ export default function CommentsLabel({
   changeInfo?: (info: CommentsAllInfoTypes) => void; // 댓글 정보 수정하기
   showCategoryName?: boolean; // 카테고리 출력 여부
   modifyRatingEvent?: (value: number) => void; // 평점 수정 이벤트 (평점 수정 가능)
-  adminLogin: boolean;
+  adminLogin: boolean | null;
 }) {
   const renderLabel = () => {
     const nodeList = [];

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
@@ -19,14 +19,13 @@ import {
   getHashText,
   changeMultipleLine,
 } from "src/main/commonsComponents/functional";
-import { getServerTime } from "src/commons/libraries/firebase";
+import { getServerTime, db } from "src/commons/libraries/firebase";
 import {
   initInfo,
   WriteInfoTypes,
   categoryListArray,
 } from "./comments.write.types";
 import { InfoTypes } from "../comments.types";
-import { db } from "src/commons/libraries/firebase";
 
 // 중복 실행 방지
 let writing = false;

--- a/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.styles.ts
+++ b/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.styles.ts
@@ -4,6 +4,7 @@ import { breakPoints } from "mcm-js-commons/dist/responsive";
 
 interface StyleTypes {
   isOpen?: boolean;
+  isAdmin?: boolean;
 }
 
 export const MobileTapWrapper = styled.nav`
@@ -18,6 +19,11 @@ export const MobileTapWrapper = styled.nav`
   align-items: center;
   padding: 0px 20px;
   z-index: 1111;
+
+  ${(props: StyleTypes) =>
+    props.isAdmin && {
+      backgroundColor: "#525FE1",
+    }}
 
   .mobile-nav-logo {
     width: 50px;

--- a/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.tsx
+++ b/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.tsx
@@ -17,9 +17,9 @@ export default function MainMobileNavigationTapPage() {
   const [module] = useRecoilState(moduleState);
   const [adminLogin] = useRecoilState(adminLoginState);
 
-  const { getRouter } = CommonsHooksComponents();
+  const { getRouter, getIsAdminPage } = CommonsHooksComponents();
   const router = getRouter();
-  const isAdmin = router.pathname.split("/")[1] === "admin";
+  const isAdmin = getIsAdminPage();
 
   // 홈으로 이동하기
   const moveHome = () => {
@@ -38,7 +38,9 @@ export default function MainMobileNavigationTapPage() {
     if (bool) {
       // 모달 오픈
       Modal.open({
-        children: <LayoutNavPage isMobileTap={true} module={module} />,
+        children: (
+          <LayoutNavPage isMobileTap={true} module={module} isAdmin={isAdmin} />
+        ),
         id: "mobile-nav-modal",
         showBGAnimation: true,
         showModalOpenAnimation: true,
@@ -58,7 +60,7 @@ export default function MainMobileNavigationTapPage() {
 
   return (
     <>
-      <MobileTapWrapper>
+      <MobileTapWrapper isAdmin={isAdmin}>
         <GoHome onClickEvent={moveHome}>🏠</GoHome>
         <MobileNavigationTap
           onClickEvent={() => toggleNav(!openNav)}

--- a/src/main/commonsComponents/withAuth/index.tsx
+++ b/src/main/commonsComponents/withAuth/index.tsx
@@ -13,78 +13,45 @@ import { checkAccessToken } from "./check";
 const WithAuthAdmin =
   <P extends {}>(Component: ComponentType<P>) =>
   (props: P) => {
-    // 로그인 상태에서만 페이지 렌더 가능
-    const [render, setRender] = useState(false);
     const [openModal, setOpenModal] = useState(false);
-    const [, setAdminLogin] = useRecoilState(adminLoginState);
+    const [adminLogin, setAdminLogin] = useRecoilState(adminLoginState);
 
     const { getRouter } = CommonsHooksComponents();
 
-    const loginComplete = () => {
-      setRender(true);
-      setAdminLogin(true);
-    };
-
     useEffect(() => {
       checkAccessToken().then((result: boolean) => {
-        if (result) {
-          // 로그인이 완료되었다면 페이지 렌더
-          loginComplete();
-        } else {
-          setAdminLogin(false);
-          setOpenModal(true);
-
-          // 로그인이 안되어 있는 경우
-          // Modal.open({
-          //   children: <AdminLoginPage loginComplete={loginComplete} />,
-          //   modalSize: { width: "360px", height: "340px" },
-          //   mobileModalSize: { height: "320px" },
-          //   modalStyles: {
-          // wrapper: {
-          //   backgroundColor: "rgba(0, 0, 0, 0.8)",
-          // },
-          // items: {
-          //   border: "double 6px #aa5656",
-          // },
-          //   },
-          //   offAutoClose: true,
-          //   onFixWindow: true,
-          //   className: "admin-login-modal",
-          //   onCloseModal: () => getRouter().replace("/"),
-          //   onAfterCloseEvent: () => {
-          //     console.log(123);
-          //   },
-          //   closeMent: "홈으로 이동",
-          // });
-        }
+        setAdminLogin(result);
+        setOpenModal(true);
       });
     }, [getRouter().pathname]);
 
     return (
       <Template isFull>
-        <Modal
-          show={openModal}
-          onCloseModal={() => {
-            getRouter().replace("/");
-          }}
-          modalSize={{ width: "360px", height: "340px" }}
-          mobileModalSize={{ height: "320px" }}
-          modalStyles={{
-            wrapper: {
-              backgroundColor: "rgba(0, 0, 0, 0.8)",
-            },
-            items: {
-              border: "double 6px #aa5656",
-            },
-          }}
-          offAutoClose
-          onFixWindow
-          className="admin-login-modal"
-          closeMent="홈으로 이동"
-        >
-          <AdminLoginPage loginComplete={loginComplete} />
-        </Modal>
-        {(render && <Component {...props} />) || <></>}
+        {openModal && !adminLogin && (
+          <Modal
+            show={!adminLogin}
+            onCloseModal={() => {
+              location.replace("/");
+            }}
+            modalSize={{ width: "360px", height: "340px" }}
+            mobileModalSize={{ height: "320px" }}
+            modalStyles={{
+              wrapper: {
+                backgroundColor: "rgba(0, 0, 0, 0.8)",
+              },
+              items: {
+                border: "double 6px #aa5656",
+              },
+            }}
+            offAutoClose
+            onFixWindow
+            className="admin-login-modal"
+            closeMent="홈으로 이동"
+          >
+            <AdminLoginPage loginComplete={() => setAdminLogin(true)} />
+          </Modal>
+        )}
+        {(adminLogin && <Component {...props} />) || <></>}
       </Template>
     );
   };

--- a/src/main/mainComponents/admin/login/index.tsx
+++ b/src/main/mainComponents/admin/login/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "./login.styles";
 
 import { Modal } from "mcm-js";
-import { _Title, _Input, _Button, _PTextWithHtml } from "mcm-js-commons";
+import { _Title, _Input } from "mcm-js-commons";
 import { FormEvent, MutableRefObject, useRef, useState } from "react";
 
 import {

--- a/src/main/mainComponents/index.tsx
+++ b/src/main/mainComponents/index.tsx
@@ -1,9 +1,7 @@
 import styled from "@emotion/styled";
 import { breakPoints } from "mcm-js-commons/dist/responsive";
-import { useEffect } from "react";
 
 import { _PText, _Title } from "mcm-js-commons";
-import { Modal } from "mcm-js";
 
 import Template from "../commonsComponents/units/template/main";
 import _SubTitleTemplate from "../commonsComponents/units/template/title/subTitle";

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -126,3 +126,7 @@ table {
     display: block;
   }
 }
+
+.admin-backcolor {
+  background-color: #525fe1;
+}


### PR DESCRIPTION
1. 해당 페이지가 관리자 페이지임을 검증할 수 있는 공통 함수 설정 완료
2. 해당 함수를 통해 지금 접속한 페이지가 관리자 페이지일 경우 유저 페이지와 다른 스타일로 렌더 설정 완료
  - 유저 페이지에서는 header의 배경, nav의 라인색, 탭의 배경색이 붉은색 게열이라면 관리자 페이지에선 파란색 계열로 나타남
3. 관리자 페이지 내에서 댓글 관리 페이지에서 아이피 관리 페이지로 이동할 경우 홈페이지로 이동되는 이슈 수정 완료
  - 모달이 자동으로 종료됨으로써 홈페이지로 이동되는 onClickEvent가 자동 실행되는 이슈
  - 따라서 관리자 로그인이 완료되어 있다면 모달 자체를 렌더하지 않는 방향으로 수정