### PR TITLE
2023-07-12 :: 차단 페이지 렌더링 방식 변경, 모바일 레이아웃 수정 및 기타 사항 보완 및 수정 완료

### DIFF
--- a/src/main/commonsComponents/units/template/form/pagination/index.tsx
+++ b/src/main/commonsComponents/units/template/form/pagination/index.tsx
@@ -1,11 +1,15 @@
-import styled from "@emotion/styled";
+import {
+  Page,
+  PageJumpWrapper,
+  PageListWrapper,
+  PagiNationWrapper,
+} from "./pagination.styles";
 
 import { memo } from "react";
-import { _Error, _Button } from "mcm-js-commons";
+import { _Error } from "mcm-js-commons";
 import { IProps, pageInfoInit } from "./pagination.types";
 
 import { getUuid } from "src/main/commonsComponents/functional";
-import { breakPoints } from "mcm-js-commons/dist/responsive";
 
 // 페이지네이션 form
 const _PagiNationForm = (props: IProps) => {
@@ -60,8 +64,6 @@ const _PagiNationForm = (props: IProps) => {
       // 처음 페이지로 이동
       num = 1;
     } else if (type === "prev") {
-      console.log(num, pageInfoList);
-
       // 이전 페이지로 이동
       num = pageInfoList.startPage - 1;
     } else if (type === "next") {
@@ -80,7 +82,7 @@ const _PagiNationForm = (props: IProps) => {
       propsList={props}
       requiredList={["allData", "currentPage", "limit", "changePageEvent"]}
     >
-      <PagiNationWrapper>
+      <PagiNationWrapper className="mcm-pagination-wrapper">
         {pageInfoList.prev && (
           <PageJumpWrapper>
             <Page onClickEvent={() => jumpPage("first")}>처음</Page>
@@ -114,51 +116,5 @@ const _PagiNationForm = (props: IProps) => {
     </_Error>
   );
 };
-
-interface StyleTypes {
-  isSelected?: boolean;
-}
-
-export const PagiNationWrapper = styled.section`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0px 20px;
-
-  @media ${breakPoints.mobileLarge} {
-    flex-wrap: wrap;
-    gap: 10px 20px;
-  }
-`;
-
-export const PageJumpWrapper = styled.div`
-  display: flex;
-  gap: 0px 10px;
-`;
-
-export const PageListWrapper = styled.ul`
-  display: flex;
-  gap: 0px 10px;
-`;
-
-export const Page = styled(_Button)`
-  font-size: 14px;
-
-  -webkit-user-select: none; // 드래그 방지
-  -moz-user-select: none;
-  -ms-use-select: none;
-  user-select: none;
-
-  ${(props: StyleTypes) =>
-    props.isSelected && {
-      cursor: "default",
-      fontWeight: 700,
-      color: "#00c4ff",
-    }}
-
-  @media ${breakPoints.mobileLarge} {
-    font-size: 12px;
-  }
-`;
 
 export default memo(_PagiNationForm);

--- a/src/main/commonsComponents/units/template/form/pagination/pagination.styles.ts
+++ b/src/main/commonsComponents/units/template/form/pagination/pagination.styles.ts
@@ -1,0 +1,50 @@
+import styled from "@emotion/styled";
+import { breakPoints } from "mcm-js-commons/dist/responsive";
+
+import { _Button } from "mcm-js-commons";
+
+interface StyleTypes {
+  isSelected?: boolean;
+}
+
+export const PagiNationWrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0px 20px;
+
+  @media ${breakPoints.mobileLarge} {
+    flex-wrap: wrap;
+    gap: 10px 20px;
+  }
+`;
+
+export const PageJumpWrapper = styled.div`
+  display: flex;
+  gap: 0px 10px;
+`;
+
+export const PageListWrapper = styled.ul`
+  display: flex;
+  gap: 0px 16px;
+
+  @media ${breakPoints.mobileLarge} {
+    flex-wrap: wrap;
+  }
+`;
+
+export const Page = styled(_Button)`
+  font-size: 14px;
+
+  -webkit-user-select: none; // 드래그 방지
+  -moz-user-select: none;
+  -ms-use-select: none;
+  user-select: none;
+
+  ${(props: StyleTypes) =>
+    props.isSelected && {
+      cursor: "default",
+      fontWeight: 700,
+      color: "#00c4ff",
+    }}
+`;

--- a/src/main/commonsComponents/units/template/form/pagination/pagination.types.ts
+++ b/src/main/commonsComponents/units/template/form/pagination/pagination.types.ts
@@ -8,11 +8,10 @@ export type IProps = {
 export interface PageInfoInitType {
   allPage: number; // 전체 페이지 개수
   pageLimit: number; // 한 블럭당 보여질 페이지 개수 (1 block = 10 page)
-  allBlock: number; // 전체 블록 개수
   next: boolean; // 다음 페이지로 이동 가능 여부
   prev: boolean; // 이전 페이지로 이동 가능 여부
-  first: boolean; // 끝 페이지로 이동 가능 여부
-  last: boolean; // 처음 페이지로 이동 가능 여부
+  //   first: boolean; // 끝 페이지로 이동 가능 여부
+  //   last: boolean; // 처음 페이지로 이동 가능 여부
   startPage: number; // 페이지네이션의 시작 페이지
 }
 
@@ -20,10 +19,9 @@ export interface PageInfoInitType {
 export const pageInfoInit: PageInfoInitType = {
   allPage: 0,
   pageLimit: 10,
-  allBlock: 0,
   next: false,
   prev: false,
-  first: false,
-  last: false,
+  //   first: false,
+  //   last: false,
   startPage: 1,
 };

--- a/src/main/commonsComponents/units/template/form/select/select.container.tsx
+++ b/src/main/commonsComponents/units/template/form/select/select.container.tsx
@@ -56,9 +56,10 @@ export default function _SelectForm(props: SelectProps) {
     if (_listRef?.current && _wrapperRef?.current) {
       window.setTimeout(() => {
         // 전체 크기 구하기
-        _wrapperRef.current.style.height = `${
-          _listRef.current.clientHeight + 4
-        }px`;
+        if (_wrapperRef?.current?.style)
+          _wrapperRef.current.style.height = `${
+            _listRef.current.clientHeight + 4
+          }px`;
 
         // window.setTimeout(() => {
         //   waiting = false;

--- a/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.styles.ts
+++ b/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.styles.ts
@@ -5,6 +5,7 @@ import { breakPoints } from "mcm-js-commons/dist/responsive";
 interface StyleTypes {
   isOpen?: boolean;
   isAdmin?: boolean;
+  hide?: boolean;
 }
 
 export const MobileTapWrapper = styled.nav`
@@ -44,6 +45,11 @@ export const MobileNavigationTap = styled(_Button)`
   justify-content: center;
   gap: 4px 0px;
 
+  ${(props: StyleTypes) =>
+    props.hide && {
+      display: "none",
+    }};
+
   ::after,
   ::before {
     content: "";
@@ -54,7 +60,7 @@ export const MobileNavigationTap = styled(_Button)`
   }
 
   ::after {
-    ${(props: StyleTypes) =>
+    ${(props) =>
       props.isOpen && {
         transform: "rotate(-45deg) translateY(-5px)",
         marginLeft: "8px",

--- a/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.tsx
+++ b/src/main/commonsComponents/units/template/main/mobileNavigation/main.mobileNavigation.tsx
@@ -66,7 +66,8 @@ export default function MainMobileNavigationTapPage() {
           onClickEvent={() => toggleNav(!openNav)}
           className="mobile-nav-button"
           isOpen={openNav}
-        ></MobileNavigationTap>
+          hide={isAdmin && !adminLogin}
+        />
       </MobileTapWrapper>
     </>
   );

--- a/src/main/mainComponents/admin/index.tsx
+++ b/src/main/mainComponents/admin/index.tsx
@@ -31,6 +31,10 @@ export const Wrapper = styled.div`
   flex-direction: column;
   gap: 100px 0px;
 
+  .admin-module-title {
+    font-size: 40px;
+  }
+
   @media ${breakPoints.mobileLarge} {
     text-align: center;
     gap: 80px 0px;

--- a/src/main/mainComponents/admin/modules/block/block.container.tsx.tsx
+++ b/src/main/mainComponents/admin/modules/block/block.container.tsx.tsx
@@ -8,7 +8,7 @@ import { checkAccessToken } from "src/main/commonsComponents/withAuth/check";
 import AdminBlockUIPage from "./block.presenter";
 
 // 필터 리스트
-const filter: FilterType = { ...filterInit };
+let filter: FilterType = { ...filterInit };
 
 export default function AdminBlockPage() {
   // 차단된 유저 리스트
@@ -17,6 +17,8 @@ export default function AdminBlockPage() {
   const [showFilter, setShowFilter] = useState(false);
   // 데이터 조회중일 경우
   const [loading, setLoading] = useState(false);
+  // 페이지 렌더하기
+  const [render, setRender] = useState(false);
 
   // 차단 리스트 가져오기
   const getBlockList = async () => {
@@ -41,8 +43,9 @@ export default function AdminBlockPage() {
     // 전체 데이터 수 가져오기
     try {
       const allDataList = await _db.get();
+      filter.allData = allDataList.size;
+
       if (allDataList.size) {
-        filter.allData = allDataList.size;
         // 데이터 조회 시작 시점
         startAt = allDataList.docs[(filter.page - 1) * filter.limit];
       }
@@ -56,27 +59,30 @@ export default function AdminBlockPage() {
       .limit(filter.limit) // 페이지별 데이터 개수 지정 (기본 : 10개)
       .get()
       .then((result) => {
-        if (!result.empty) {
-          const dataList: Array<BlockInfoType> = [];
+        console.log(result.size);
+        // if (!result.empty) {
+        const dataList: Array<BlockInfoType> = [];
 
-          result.forEach((info) => {
-            const _info = info.data() as BlockInfoType;
+        result.forEach((info) => {
+          const _info = info.data() as BlockInfoType;
 
-            const inputId = getUuid();
-            _info.id = info.id;
-            // checkbox의 inputId 값 추가
-            _info.inputId = inputId;
-            // 체크 여부 검증
-            _info.checked = false;
+          const inputId = getUuid();
+          _info.id = info.id;
+          // checkbox의 inputId 값 추가
+          _info.inputId = inputId;
+          // 체크 여부 검증
+          _info.checked = false;
 
-            dataList.push(_info);
-          });
+          dataList.push(_info);
+        });
 
-          if (dataList && dataList.length) {
-            setBlockList(dataList);
-          }
-          setLoading(false);
-        }
+        // if (dataList && dataList.length) {
+        setBlockList(dataList);
+        // }
+        // }
+        setLoading(false);
+
+        if (!render) setRender(true);
       })
       .catch((err) => {
         console.log(err);
@@ -85,6 +91,7 @@ export default function AdminBlockPage() {
   };
 
   useEffect(() => {
+    filter = { ...filterInit };
     getBlockList();
   }, []);
 
@@ -173,6 +180,7 @@ export default function AdminBlockPage() {
       cancelBlock={cancelBlock}
       changePage={changePage}
       isLoading={loading}
+      render={render}
     />
   );
 }

--- a/src/main/mainComponents/admin/modules/block/block.presenter.tsx
+++ b/src/main/mainComponents/admin/modules/block/block.presenter.tsx
@@ -35,79 +35,81 @@ export default function AdminBlockUIPage(props: IProps) {
     cancelBlock,
     changePage,
     isLoading,
+    render,
   } = props;
 
-  return (
+  return render ? (
     <Wrapper>
-      {!blockList.length ? (
+      {/* {(!blockList.length && (
         <_Title className="empty-block-list-title">
           차단된 유저가 없습니다.
         </_Title>
-      ) : (
-        <BlockListWrapper>
-          {isLoading && (
-            <LoadingData>
-              <_SpanText className="loading-data">데이터 로딩 중</_SpanText>
-            </LoadingData>
-          )}
-          <OptionalWrapper>
-            <_PText>- {filter.allData}명의 차단된 유저가 있습니다.</_PText>
+      )) || ( */}
+      <BlockListWrapper>
+        {isLoading && (
+          <LoadingData>
+            <_SpanText className="loading-data">데이터 로딩 중</_SpanText>
+          </LoadingData>
+        )}
+        <OptionalWrapper>
+          <_PText>- 총 {filter.allData}명의 차단된 유저가 있습니다.</_PText>
 
-            <FilterWrapper>
-              <FilterItems>
-                <_Button onClickEvent={() => toggleShowFilter(true)}>
-                  <_Image
-                    src={`/images/commons/icons/filter-${
-                      getFilterOn() ? "on" : "off"
-                    }.png`}
-                    className="filter-icon"
-                  />
-                </_Button>
-                <_SelectForm
-                  show={showFilter}
-                  closeEvent={() => toggleShowFilter(false)}
-                  className="block-filter-list"
-                >
-                  <_Button
-                    onClickEvent={() => fetchFilter("showOnlyBlock")}
-                    className={`show-block-user-btn ${
-                      (filter.showOnlyBlock && "selected") || undefined
-                    }`}
-                  >
-                    차단중인 유저만 보기
-                  </_Button>
-                  <_Button
-                    onClickEvent={() => fetchFilter("past")}
-                    className={`show-past-user-btn ${
-                      (filter.past && "selected") || undefined
-                    }`}
-                  >
-                    과거순으로 보기
-                  </_Button>
-                </_SelectForm>
-              </FilterItems>
-
-              <_Button
-                onClickEvent={cancelBlock}
-                className="remove-block-user-btn"
-              >
-                선택 차단 해제
+          <FilterWrapper>
+            <FilterItems>
+              <_Button onClickEvent={() => toggleShowFilter(true)}>
+                <_Image
+                  src={`/images/commons/icons/filter-${
+                    getFilterOn() ? "on" : "off"
+                  }.png`}
+                  className="filter-icon"
+                />
               </_Button>
-            </FilterWrapper>
-          </OptionalWrapper>
-          <BlockListItems isLoading={isLoading || false}>
-            <thead>
-              <Tr>
-                <td className="block-select"></td>
-                <td className="block-ip">아이피</td>
-                <td className="block-contents">차단 사유</td>
-                <td className="block-date">차단일</td>
-                <td className="block-cancel">차단 해제일</td>
-              </Tr>
-            </thead>
+              <_SelectForm
+                show={showFilter}
+                closeEvent={() => toggleShowFilter(false)}
+                className="block-filter-list"
+              >
+                <_Button
+                  onClickEvent={() => fetchFilter("showOnlyBlock")}
+                  className={`show-block-user-btn ${
+                    (filter.showOnlyBlock && "selected") || undefined
+                  }`}
+                >
+                  차단중인 유저만 보기
+                </_Button>
+                <_Button
+                  onClickEvent={() => fetchFilter("past")}
+                  className={`show-past-user-btn ${
+                    (filter.past && "selected") || undefined
+                  }`}
+                >
+                  과거순으로 보기
+                </_Button>
+              </_SelectForm>
+            </FilterItems>
 
-            <tbody>
-              {blockList.map((info, idx) => {
+            <_Button
+              onClickEvent={cancelBlock}
+              className="remove-block-user-btn"
+            >
+              선택 차단 해제
+            </_Button>
+          </FilterWrapper>
+        </OptionalWrapper>
+        <BlockListItems isLoading={isLoading || false}>
+          <thead>
+            <Tr>
+              <td className="block-select"></td>
+              <td className="block-ip">아이피</td>
+              <td className="block-contents">차단 사유</td>
+              <td className="block-date">차단일</td>
+              <td className="block-cancel">차단 해제일</td>
+            </Tr>
+          </thead>
+
+          <tbody>
+            {blockList.length ? (
+              blockList.map((info, idx) => {
                 // 이미 차단이 해제된 유저인지 체크
                 const alreadyCancel = info.canceledAt !== null;
                 // 선택한 유저인지 체크
@@ -157,10 +159,16 @@ export default function AdminBlockUIPage(props: IProps) {
                     </td>
                   </Tr>
                 );
-              })}
-            </tbody>
-          </BlockListItems>
+              })
+            ) : (
+              <_Title titleLevel="h2" className="empty-filter-list">
+                조회된 유저가 없습니다.
+              </_Title>
+            )}
+          </tbody>
+        </BlockListItems>
 
+        {(blockList.length && (
           <_PagiNationForm
             // allData={1201}
             currentPage={filter.page}
@@ -168,8 +176,12 @@ export default function AdminBlockUIPage(props: IProps) {
             limit={filter.limit}
             changePageEvent={changePage}
           />
-        </BlockListWrapper>
-      )}
+        )) ||
+          undefined}
+      </BlockListWrapper>
+      {/* )} */}
     </Wrapper>
+  ) : (
+    <_Title>리스트 불러오는 중...</_Title>
   );
 }

--- a/src/main/mainComponents/admin/modules/block/block.styles.ts
+++ b/src/main/mainComponents/admin/modules/block/block.styles.ts
@@ -5,6 +5,7 @@ interface StyleTypes {
   isTbody?: boolean;
   alreadyCancel?: boolean;
   isLoading?: boolean;
+  render?: boolean;
 }
 
 export const Wrapper = styled.div`
@@ -16,6 +17,10 @@ export const Wrapper = styled.div`
     letter-spacing: -0.05rem;
     color: gray;
   }
+
+  @media ${breakPoints.mobileLarge} {
+    padding-bottom: 30px;
+  }
 `;
 
 export const BlockListWrapper = styled.div`
@@ -24,6 +29,18 @@ export const BlockListWrapper = styled.div`
   position: relative;
   gap: 12px 0px;
   transition: all 0.3s;
+
+  @media ${breakPoints.mobileLarge} {
+    .mcm-pagination-wrapper {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      padding: 10px 0px;
+      background-color: white;
+      border-top: double 2px black;
+    }
+  }
 `;
 
 export const OptionalWrapper = styled.div`
@@ -43,6 +60,12 @@ export const BlockListItems = styled.table`
 
   .checked {
     background-color: #efefef;
+  }
+
+  .empty-filter-list {
+    padding: 20px;
+    text-align: center;
+    color: gray;
   }
 
   thead {
@@ -112,6 +135,11 @@ export const BlockListItems = styled.table`
       display: none;
     }
 
+    .empty-filter-list {
+      padding: 16px;
+      font-size: 30px;
+    }
+
     tbody {
       tr {
         .block-contents {
@@ -131,6 +159,12 @@ export const BlockListItems = styled.table`
           }
         }
       }
+    }
+  }
+
+  @media ${breakPoints.mobileSmall} {
+    .empty-filter-list {
+      font-size: 24px;
     }
   }
 `;
@@ -249,7 +283,7 @@ export const LoadingData = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 10;
 
   -webkit-user-select: none; // 드래그 방지
   -moz-user-select: none;
@@ -266,3 +300,5 @@ export const LoadingData = styled.div`
     padding-bottom: 100px;
   }
 `;
+
+export const Rendering = styled.div``;

--- a/src/main/mainComponents/admin/modules/block/block.types.ts
+++ b/src/main/mainComponents/admin/modules/block/block.types.ts
@@ -33,4 +33,5 @@ export interface IProps {
   cancelBlock: () => void;
   changePage: (page: number) => void;
   isLoading: boolean;
+  render: boolean;
 }


### PR DESCRIPTION
1. 기존 차단 페이지에 첫 접속했을 때, 리스트가 없는 경우 "유저를 찾지 못했습니다."라는 문구가 먼저 출력이 되고 후에 데이터를 조회한 후 리스트가 뿌려지는 순서로 진행되었음. 이 순서를 보완하기 위해 render 이름의 state가 true일 때 전체 Block 페이지를 렌더하고 데이터를 조회했을 때 리스트가 비어있든 비어있지 않든 render를 true로 변경해 데이터를 분할해서 렌더하도록 변경함
2. 차단 페이지내 모바일 환경에서 페이지네이션이 하단부에 위치해 스크롤을 끝까지 내려야만 조작할 수 있는 불편함을 최소화하기 위해 모바일 환경에서는 페이지네이션이 자동으로 하단부에 fixed 될 수 있도록 변경
3. 차단 페이지를 벗어날 경우 설정되어 있는 필터가 해제되지 않고 계속 유지되는 현상 수정 완료