### PR TITLE
2023-07-26 :: 댓글 API 리뉴얼 2차 완료 및 댓글 확장 기능 이슈 사항 수정 완료

### DIFF
--- a/src/commons/libraries/apis/comments/count/count.apis.ts
+++ b/src/commons/libraries/apis/comments/count/count.apis.ts
@@ -1,45 +1,43 @@
 import {
   CollectionReferenceDocumentData,
   QueryDocumentData,
+  QueryDocumentSnapshotDocumentData,
   getDoc,
 } from "src/commons/libraries/firebase";
 import { WriteInfoTypes } from "src/main/commonsComponents/units/template/form/comments/write/comments.write.types";
 
 // 카운트 관련 apis
-const countApis = ({
-  countDocs,
-  module,
-}: {
-  countDocs?: CollectionReferenceDocumentData;
-  module: string;
-}) => {
-  let countDoc: QueryDocumentData =
-    countDocs || getDoc("comments", module, "count");
+const countApis = ({ module }: { module: string }) => {
+  let countDoc: QueryDocumentData = getDoc("comments", module, "count");
+
+  // update를 제외한 결과 객체
+  const result: ReturnResultType = {
+    countList: {},
+    docId: "",
+  };
 
   return {
     // 댓글 추가시 카운트 업데이트 (최종 업데이트 X)
     add: async ({
       input,
-      //   countList,
-      getDocId,
+      countList, // 외부에서 넘겨주는 카운트 리스트
     }: {
       input: WriteInfoTypes;
-      //   countList?: CountListType;
-      getDocId?: boolean;
-    }): Promise<{ countList: CountListType; docId: string }> => {
-      const result: { countList: CountListType; docId: string } = {
-        countList: {},
-        docId: "",
+      countList?: {
+        countList: { [key: string]: string | number };
+        docId: string;
       };
+    }): Promise<ReturnResultType> => {
       // 해당 카테고리 조회
-      countDoc = countDoc.where("category", "==", input.category);
-      const getCountDoc = (await countDoc.get()).docs[0];
+      const getCountDoc =
+        countList || (await countApis({ module }).getCountDoc(input.category));
 
-      let _countList = getCountDoc.data();
+      let _countList = getCountDoc.countList;
+
       // 전체 카테고리 개수 1개 추가
       _countList = { ..._countList, ["count"]: _countList.count + 1 };
       // docId 가져오기
-      result.docId = getCountDoc.id;
+      result.docId = getCountDoc.docId;
 
       // 이슈, 리뷰일 경우 각각의 필터 1개 더하기
       if (_countList.category !== "question") {
@@ -51,7 +49,90 @@ const countApis = ({
       return result;
     },
     // 댓글 삭제시 카운트 업데이트 (최종 업데이트 X)
-    remove: async () => {},
+    remove: async ({
+      input,
+    }: {
+      input: WriteInfoTypes;
+    }): Promise<ReturnResultType> => {
+      // 해당 카테고리 조회
+      const getCountDoc = await countApis({ module }).getCountDoc(
+        input.category
+      );
+      let _countList = getCountDoc.countList;
+
+      // 전체 카테고리 개수 1개 제거
+      _countList = { ..._countList, ["count"]: _countList.count - 1 };
+      // docId 가져오기
+      result.docId = getCountDoc.docId;
+
+      const { category } = input;
+      // 버그 또는 리뷰 별 접근할 컬럼 이름
+      const target = category === "bug" ? "bugLevel" : "rating";
+
+      if (category === "question") {
+        // 카테고리가 문의일 경우
+        if (input.answer && input.answerCreatedAt) {
+          // 답장이 등록되어 있는 경우, "답장 완료(question-complete)" 1개 제거
+          _countList["question-complete"]--;
+        }
+      } else {
+        // 카테고리가 버그 또는 리뷰일 경우
+        // 해당 점수(버그 레벨 및 평점) 1개 삭제
+        _countList[`${category}-${input[target]}`]--;
+
+        if (category === "bug" && input.bugStatus === 2) {
+          // 이슈일 때, "해결 완료(bug-complete)"라면 해당 필터도 1개 제거
+          _countList["bug-complete"]--;
+        }
+      }
+      result.countList = _countList;
+
+      return result;
+    },
+    // 댓글 수정시 카운트 업데이트 (최종 업데이트 X)
+    modify: async ({
+      originInput,
+      changeInput,
+    }: {
+      originInput: WriteInfoTypes;
+      changeInput: WriteInfoTypes;
+    }): Promise<ReturnResultType> => {
+      // 해당 카테고리 조회
+      const getCountDoc = await countApis({ module }).getCountDoc(
+        originInput.category
+      );
+      let _countList = getCountDoc.countList;
+      result.docId = getCountDoc.docId;
+
+      const { category } = originInput;
+      if (category === "question") {
+        // 카테고리가 문의일 경우
+        if (!originInput.answer && changeInput.answer) {
+          // 새로운 답변이 등록된다면, "question-complete" 1개 추가
+          _countList["question-complete"]++;
+        }
+      } else {
+        // 이슈 및 리뷰일 경우 변경된 점수로 업데이트
+        const target = category === "bug" ? "bugLevel" : "rating";
+        if (originInput[target] !== changeInput[target]) {
+          // 점수를 변경했을 경우
+          _countList[`${category}-${originInput[target]}`]--; // 기존의 점수는 1개 제거
+          _countList[`${category}-${changeInput[target]}`]++; // 변경된 점수는 1개 추가
+        }
+
+        // 이슈 카테고리에서
+        if (category === "bug") {
+          // 답변이 완료될 경우
+          if (originInput.bugStatus !== 2 && changeInput.bugStatus === 2) {
+            _countList["bug-complete"]++;
+          }
+        }
+      }
+      result.countList = _countList;
+
+      return result;
+    },
+
     // 카운트 최종 업데이트
     update: async (
       docId: string,
@@ -79,9 +160,32 @@ const countApis = ({
 
       return result;
     },
+    // 카운트 Doc 가져오기
+    getCountDoc: async (category: string) => {
+      const docs = (await countDoc.where("category", "==", category).get())
+        .docs[0];
+      return {
+        countList: docs.data(),
+        docId: docs.id,
+      };
+    },
+    // 전체 리스트 가져오기
+    getAllCountList: async () => {
+      return (await countDoc.get()).docs.reduce(
+        (acc: { [category: string]: any }, cur) => {
+          const data = cur.data() as { [key: string]: string | number };
+
+          acc[data.category] = data;
+          acc[data.category].id = cur.id;
+          return acc;
+        },
+        {}
+      );
+    },
   };
 };
 
 export default countApis;
 
 export type CountListType = { [key: string]: string | number };
+export type ReturnResultType = { countList: CountListType; docId: string };

--- a/src/main/commonsComponents/functional/index.ts
+++ b/src/main/commonsComponents/functional/index.ts
@@ -192,6 +192,17 @@ const deepCopy = <T>(data: T) => {
   return JSON.parse(JSON.stringify(data));
 };
 
+// 비밀번호 동일 체크
+const checkSamePassword = async (
+  hashPassword: string,
+  inputPassword: string
+): Promise<boolean> => {
+  // hashPassword : 기존에 해쉬 형태로 저장되어 있는 원본 비밀번호
+  // inputPassword : 비교할 비밀번호 (해쉬 X)
+
+  return hashPassword === (await getHashText(inputPassword));
+};
+
 export {
   removeTag,
   getDateForm,
@@ -203,4 +214,5 @@ export {
   getBugAutoAnswer,
   getRandomNumber,
   deepCopy,
+  checkSamePassword,
 };

--- a/src/main/commonsComponents/units/template/form/comments/comments.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/comments.container.tsx
@@ -318,149 +318,149 @@ export default function CommentsPage() {
   };
 
   // 댓글 정보 수정하기
-  const modifyComments = async (
-    comment: InfoTypes,
-    isDelete?: boolean,
-    type?: string,
-    origin?: InfoTypes
-  ): Promise<boolean> => {
-    const {
-      category,
-      id,
-      rating,
-      bugLevel,
-      answer,
-      bugStatus,
-      answerCreatedAt,
-    } = comment;
+  // const modifyComments = async (
+  //   comment: InfoTypes,
+  //   isDelete?: boolean,
+  //   type?: string,
+  //   origin?: InfoTypes
+  // ): Promise<boolean> => {
+  //   const {
+  //     category,
+  //     id,
+  //     rating,
+  //     bugLevel,
+  //     answer,
+  //     bugStatus,
+  //     answerCreatedAt,
+  //   } = comment;
 
-    try {
-      // 댓글 정보 수정하기
-      const modifyDoc = getCommentDoc().doc(id);
-      // 수정 전의 원본 복사하기
-      const originData = (await modifyDoc.get()).data() as InfoTypes;
-      // 댓글 수정 요청
-      await modifyDoc.update(comment);
+  //   try {
+  //     // 댓글 정보 수정하기
+  //     const modifyDoc = getCommentDoc().doc(id);
+  //     // 수정 전의 원본 복사하기
+  //     const originData = (await modifyDoc.get()).data() as InfoTypes;
+  //     // 댓글 수정 요청
+  //     await modifyDoc.update(comment);
 
-      const editData = (await modifyDoc.get()).data() as InfoTypes;
-      if (editData) {
-        const _info = { ...commentsInfo };
+  //     const editData = (await modifyDoc.get()).data() as InfoTypes;
+  //     if (editData) {
+  //       const _info = { ...commentsInfo };
 
-        // 수정이 완료된 경우
-        // 해당 카테고리의 전체 개수 데이터 가져오기
-        const updateDoc = await getCommentsCountList(category);
+  //       // 수정이 완료된 경우
+  //       // 해당 카테고리의 전체 개수 데이터 가져오기
+  //       const updateDoc = await getCommentsCountList(category);
 
-        if (!updateDoc.empty) {
-          const result = updateDoc.docs[0].data();
-          const countList: {
-            [key: string]: number | CategoryTypes;
-          } = { ...result };
+  //       if (!updateDoc.empty) {
+  //         const result = updateDoc.docs[0].data();
+  //         const countList: {
+  //           [key: string]: number | CategoryTypes;
+  //         } = { ...result };
 
-          if (isDelete) {
-            // 삭제라면 해당 카테고리 개수 및 필터 개수 업데이트
-            // 전체 개수(count) 1개 제거하기
-            countList.count = Number(countList.count) - 1;
+  //         if (isDelete) {
+  //           // 삭제라면 해당 카테고리 개수 및 필터 개수 업데이트
+  //           // 전체 개수(count) 1개 제거하기
+  //           countList.count = Number(countList.count) - 1;
 
-            // 카테고리가 리뷰 또는 버그일 경우
-            if (category === "review" || category === "bug") {
-              const target = category === "review" ? rating : bugLevel;
-              // 해당 필터 점수에서도 1개 제거
-              countList[`${category}-${target}`] =
-                Number(countList[`${category}-${target}`]) - 1;
-            }
-          }
+  //           // 카테고리가 리뷰 또는 버그일 경우
+  //           if (category === "review" || category === "bug") {
+  //             const target = category === "review" ? rating : bugLevel;
+  //             // 해당 필터 점수에서도 1개 제거
+  //             countList[`${category}-${target}`] =
+  //               Number(countList[`${category}-${target}`]) - 1;
+  //           }
+  //         }
 
-          // 카테고리가 리뷰 또는 버그일 경우
-          if (
-            category === "review" ||
-            category === "bug" ||
-            category === "question"
-          ) {
-            // 어떤 점수 필터를 하나 제거할건지 정한다.
-            let originTargetData = category === "review" ? rating : bugLevel;
-            // 비교할 원본 데이터
-            const _originData =
-              category === "review" ? originData.rating : originData.bugLevel;
-            // 변경된 데이터
-            const changeData = originTargetData;
+  //         // 카테고리가 리뷰 또는 버그일 경우
+  //         if (
+  //           category === "review" ||
+  //           category === "bug" ||
+  //           category === "question"
+  //         ) {
+  //           // 어떤 점수 필터를 하나 제거할건지 정한다.
+  //           let originTargetData = category === "review" ? rating : bugLevel;
+  //           // 비교할 원본 데이터
+  //           const _originData =
+  //             category === "review" ? originData.rating : originData.bugLevel;
+  //           // 변경된 데이터
+  //           const changeData = originTargetData;
 
-            if (!isDelete && changeData !== _originData) {
-              // 수정이면서, 점수를 변경했을 경우에는 기존에 있던 점수를 1개 제거한다.
-              originTargetData = _originData;
-            }
+  //           if (!isDelete && changeData !== _originData) {
+  //             // 수정이면서, 점수를 변경했을 경우에는 기존에 있던 점수를 1개 제거한다.
+  //             originTargetData = _originData;
+  //           }
 
-            if (originTargetData !== changeData) {
-              // 해당 필터 점수에서도 1개 제거
-              countList[`${category}-${originTargetData}`] =
-                Number(countList[`${category}-${originTargetData}`]) - 1;
+  //           if (originTargetData !== changeData) {
+  //             // 해당 필터 점수에서도 1개 제거
+  //             countList[`${category}-${originTargetData}`] =
+  //               Number(countList[`${category}-${originTargetData}`]) - 1;
 
-              // 새로 변경한 점수의 필터를 1개 증가시킨다.
-              countList[`${category}-${changeData}`] =
-                Number(countList[`${category}-${changeData}`]) + 1;
-            }
+  //             // 새로 변경한 점수의 필터를 1개 증가시킨다.
+  //             countList[`${category}-${changeData}`] =
+  //               Number(countList[`${category}-${changeData}`]) + 1;
+  //           }
 
-            // 이슈 완료일 경우 필터 변경
-            if (category === "bug" && bugStatus === 2) {
-              if (type === "question") {
-                if (comment.bugStatus !== origin?.bugStatus) {
-                  // 답변 완료일 경우 필터에서 1개 증가
-                  countList["bug-complete"] =
-                    Number(countList["bug-complete"]) + 1;
-                }
-              } else if (type === "delete" || type === "block") {
-                // 삭제, 차단일 경우 필터에서 1개 감소
-                countList["bug-complete"] =
-                  Number(countList["bug-complete"]) - 1;
-              }
-            } else if (category === "question") {
-              if (type === "question") {
-                if (!origin?.answer && !origin?.answerCreatedAt) {
-                  // 답변이 등록된 경우, 답변 완료 필터 1개 증가
-                  countList["question-complete"] =
-                    Number(countList["question-complete"]) + 1;
-                }
-              } else if (type === "delete" || type === "block") {
-                if (answer && answerCreatedAt) {
-                  // 삭제, 차단일 경우 필터에서 1개 감소
-                  countList["question-complete"] =
-                    Number(countList["question-complete"]) - 1;
-                }
-              }
-            }
-          }
+  //           // 이슈 완료일 경우 필터 변경
+  //           if (category === "bug" && bugStatus === 2) {
+  //             if (type === "question") {
+  //               if (comment.bugStatus !== origin?.bugStatus) {
+  //                 // 답변 완료일 경우 필터에서 1개 증가
+  //                 countList["bug-complete"] =
+  //                   Number(countList["bug-complete"]) + 1;
+  //               }
+  //             } else if (type === "delete" || type === "block") {
+  //               // 삭제, 차단일 경우 필터에서 1개 감소
+  //               countList["bug-complete"] =
+  //                 Number(countList["bug-complete"]) - 1;
+  //             }
+  //           } else if (category === "question") {
+  //             if (type === "question") {
+  //               if (!origin?.answer && !origin?.answerCreatedAt) {
+  //                 // 답변이 등록된 경우, 답변 완료 필터 1개 증가
+  //                 countList["question-complete"] =
+  //                   Number(countList["question-complete"]) + 1;
+  //               }
+  //             } else if (type === "delete" || type === "block") {
+  //               if (answer && answerCreatedAt) {
+  //                 // 삭제, 차단일 경우 필터에서 1개 감소
+  //                 countList["question-complete"] =
+  //                   Number(countList["question-complete"]) - 1;
+  //               }
+  //             }
+  //           }
+  //         }
 
-          // 리스트 업데이트
-          const updateReulst = await updateCountList(
-            updateDoc.docs[0].id,
-            countList
-          );
+  //         // 리스트 업데이트
+  //         const updateReulst = await updateCountList(
+  //           updateDoc.docs[0].id,
+  //           countList
+  //         );
 
-          if (updateReulst) {
-            const { count, category, ...countFilterList } = countList as {
-              [key: string]: number;
-            };
-            _info.countList[category] = Number(countList.count);
+  //         if (updateReulst) {
+  //           const { count, category, ...countFilterList } = countList as {
+  //             [key: string]: number;
+  //           };
+  //           _info.countList[category] = Number(countList.count);
 
-            _info.countFilterList = {
-              ..._info.countFilterList,
-              ...countFilterList,
-            };
+  //           _info.countFilterList = {
+  //             ..._info.countFilterList,
+  //             ...countFilterList,
+  //           };
 
-            fetchCommentsList(_info);
-            return true;
-          }
-          return false;
-        }
+  //           fetchCommentsList(_info);
+  //           return true;
+  //         }
+  //         return false;
+  //       }
 
-        return false;
-      }
-    } catch (err) {
-      console.log(`댓글 수정에 실패했습니다. ${err}`);
-      return false;
-    }
-    // }
-    return false;
-  };
+  //       return false;
+  //     }
+  //   } catch (err) {
+  //     console.log(`댓글 수정에 실패했습니다. ${err}`);
+  //     return false;
+  //   }
+  //   // }
+  //   return false;
+  // };
 
   // 댓글 개수 리스트 DOC 가져오기
   const getCommentsCountList = async (category: string) => {
@@ -519,7 +519,6 @@ export default function CommentsPage() {
   return (
     <CommentsUIPage
       commentsInfo={commentsInfo}
-      modifyComments={modifyComments}
       changeInfo={changeInfo}
       moreLoad={moreLoad}
       adminLogin={adminLogin}

--- a/src/main/commonsComponents/units/template/form/comments/comments.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/comments.presenter.tsx
@@ -12,7 +12,6 @@ import { _Title } from "mcm-js-commons";
 
 export default function CommentsUIPage({
   commentsInfo,
-  modifyComments,
   changeInfo,
   moreLoad,
   adminLogin,
@@ -22,7 +21,6 @@ export default function CommentsUIPage({
   loading,
 }: {
   commentsInfo: CommentsAllInfoTypes;
-  modifyComments: (comment: InfoTypes, isDelete?: boolean) => Promise<boolean>;
   changeInfo: (info: CommentsAllInfoTypes) => void;
   moreLoad: () => void;
   adminLogin: boolean;
@@ -70,7 +68,6 @@ export default function CommentsUIPage({
           <_InfinityScroll moreLoad={moreLoad}>
             <CommentsListPage
               commentsInfo={commentsInfo}
-              modifyComments={modifyComments}
               changeInfo={changeInfo}
               adminLogin={adminLogin}
               fetchCommentsList={fetchCommentsList}

--- a/src/main/commonsComponents/units/template/form/comments/list/comments.list.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/comments.list.container.tsx
@@ -7,10 +7,9 @@ import { MutableRefObject, useEffect, useRef } from "react";
 let saveCategory = "all";
 export default function CommentsListPage(props: {
   commentsInfo: CommentsAllInfoTypes;
-  modifyComments: (comment: InfoTypes, isDelete?: boolean) => Promise<boolean>;
   changeInfo: (info: CommentsAllInfoTypes) => void;
   adminLogin: boolean;
-  fetchCommentsList: (info: CommentsAllInfoTypes, startPage: number) => void;
+  fetchCommentsList: (info?: CommentsAllInfoTypes, startPage?: number) => void;
 }) {
   const { commentsInfo, fetchCommentsList } = props;
   const listRef = useRef() as MutableRefObject<HTMLUListElement>;

--- a/src/main/commonsComponents/units/template/form/comments/list/comments.list.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/comments.list.presenter.tsx
@@ -23,16 +23,16 @@ import _PaginationForm from "../../pagination";
 
 export default function CommentsListUIPage({
   commentsInfo,
-  modifyComments,
   changeInfo,
   listRef,
+  fetchCommentsList,
 }: // changePage,
 {
   commentsInfo: CommentsAllInfoTypes;
-  modifyComments: (comment: InfoTypes, isDelete?: boolean) => Promise<boolean>;
   changeInfo: (info: CommentsAllInfoTypes) => void;
   listRef: MutableRefObject<HTMLUListElement>;
   changePage: (page: number) => void;
+  fetchCommentsList: (info?: CommentsAllInfoTypes) => void;
 }) {
   return (
     <CommentsListWrapper id="comments-list-wrapper">
@@ -92,9 +92,9 @@ export default function CommentsListUIPage({
             <ListContentsInfoPage
               key={getUuid()}
               info={el}
-              modifyComments={modifyComments}
               commentsInfo={commentsInfo}
               changeInfo={changeInfo}
+              fetchCommentsList={fetchCommentsList}
             />
           ))}
           {/* <PaginationWrapper>

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/list.contents.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/list.contents.container.tsx
@@ -17,15 +17,15 @@ import { ListContentsSelectType } from "./list.data";
 
 export interface ListContentsIProps {
   info: InfoTypes;
-  modifyComments: (comment: InfoTypes, isDelete?: boolean) => Promise<boolean>;
   commentsInfo: CommentsAllInfoTypes;
   changeInfo: (info: CommentsAllInfoTypes) => void;
+  fetchCommentsList: (info?: CommentsAllInfoTypes) => void;
 }
 
 const MAX_LINE = 160; // 더 보기가 실행 될 최소 글자수
 
 export default function ListContentsInfoPage(props: ListContentsIProps) {
-  const { info, modifyComments, changeInfo } = props;
+  const { info, changeInfo, fetchCommentsList } = props;
   const { contents } = info;
 
   const [adminLogin] = useRecoilState(adminLoginState);
@@ -89,9 +89,9 @@ export default function ListContentsInfoPage(props: ListContentsIProps) {
         <ContentsOptionalPage
           type={type}
           info={info}
-          modifyComments={modifyComments}
           adminLogin={adminLogin}
           module={module}
+          fetchCommentsList={fetchCommentsList}
         />
       ),
       id: "comments-functional-modal",

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/list.contents.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/list.contents.presenter.tsx
@@ -64,6 +64,8 @@ export default function ListContentsInfoUIPage({
     else if (info.category === "review") answerClass += " review-answer";
   }
 
+  console.log(info.modifyAt, info);
+
   return (
     <CommentsList
       hover={hover}

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.data.ts
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.data.ts
@@ -18,3 +18,11 @@ export const AdminBugStatusSelectList: Array<AdminBugStatusSelectListType> = [
     status: 2,
   },
 ];
+
+// afterEvent용 key 체인지 객체
+export const exchangeKey: { [key: string]: string } = {
+  emptyPassword: "비밀번호를 입력해주세요.",
+  emptyContents: "댓글 내용을 입력해주세요.",
+  emptyAnswer: "답변을 입력해주세요.",
+  failPassword: "비밀번호가 일치하지 않습니다.",
+};

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.presenter.tsx
@@ -31,22 +31,22 @@ export default function ContentsSelectFunctionalUIPage({
   changeData,
   confirm,
   adminLogin,
-  waiting,
   changeBugStatus,
   bugStatus,
+  answerRef,
 }: {
   type: ListContentsSelectType;
   info: InfoTypes;
   passwordRef: MutableRefObject<HTMLInputElement>;
   contentsRef: MutableRefObject<HTMLTextAreaElement>;
   confirmRef: MutableRefObject<HTMLButtonElement>;
+  answerRef: MutableRefObject<HTMLTextAreaElement>;
   changeData: (
     value: string | number,
     type: "contents" | "password" | "rating" | "bugLevel" | "answer"
   ) => void;
   confirm: (e?: FormEvent) => void;
   adminLogin: boolean | null;
-  waiting: boolean;
   changeBugStatus: (status: number) => void;
   bugStatus: number;
 }) {
@@ -98,6 +98,7 @@ export default function ContentsSelectFunctionalUIPage({
               maxLength={500}
               defaultValue={info.answer?.split("<br />").join("\n")}
               readOnly={!isAnswerType || !adminLogin}
+              inputRef={answerRef}
             />
           )}
         </CommentsInfoItems>
@@ -142,13 +143,8 @@ export default function ContentsSelectFunctionalUIPage({
         )}
 
         <ConfirmButtonWrapper>
-          <ConfirmButton
-            onClickEvent={() => (waiting ? confirm : undefined)}
-            // className="confirm-button disable"
-            buttonRef={confirmRef}
-            waiting={waiting}
-          >
-            {waiting ? "처리중입니다..." : ContentsSelectTypeName[type][1]}
+          <ConfirmButton onClickEvent={confirm} buttonRef={confirmRef}>
+            {ContentsSelectTypeName[type][1]}
           </ConfirmButton>
         </ConfirmButtonWrapper>
       </OptionalWrapper>

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
@@ -221,7 +221,9 @@ export default function CommentsWritePage({
       if (input.category !== "review") input.rating = 0;
 
       // 댓글 추가하기
-      const addResult = await commentsApis({ module, input }).addComments(true);
+      const addDocs = await commentsApis({ module, input });
+      const addResult = await addDocs.addComments(true);
+
       const _info = { ...commentsInfo };
 
       Modal.close({ id: "writing-modal" });


### PR DESCRIPTION
1. 댓글 삭제, 수정, 답변 API 분할 작업 완료
2. 댓글 작성 및 삭제, 수정, 차단에 따라 변환되는 카테고리 개수 업데이트 API 분할 작업 완료
3. 댓글 수정시 다른 평점 및 다른 이슈레벨을 선택했을 때 순간적으로 원래의 점수로 되돌아오는 현상 수정 완료
4. 관리자 답장 빈칸 입력시 에러메세지가 출력되지 않은 이슈 수정 완료
5. 기존 댓글 확장 기능 사용시 실제로 생성된 댓글의 개수와 카테고리 개수가 동기화되지 않던 이슈 수정 완료
  - 10개의 랜덤한 댓글을 생성했을 때 이슈 2개, 문의 5개, 리뷰 3개의 댓글이 생성되었을 때, 카테고리 개수 업데이트에서는 DB에 저장된 개수 리스트를 10번씩 가져오는 형태로 데이터가 쌓이지 않는 문제로 판단, 전체 카테고리 개수를 먼저 가져온 후에 10번의 반복에서 해당 카테고리의 개수를 계속해서 업데이트 한 후에 마지막에 1번만 최종 저장하는 형태로 변경