### PR TITLE
2023-08-02 :: 관리자 댓글 페이지 필터 기능 추가 및 삭제된 댓글 보기 기능 추가 완료

### DIFF
--- a/src/commons/libraries/apis/block/block.apis.ts
+++ b/src/commons/libraries/apis/block/block.apis.ts
@@ -1,8 +1,6 @@
-import { getDoc } from "../../firebase";
+import { getDoc, getServerTime } from "../../firebase";
 import { AddBlockInputType, BlockInputTypes } from "./block.types";
 import { BlockInfoTypes } from "src/main/commonsComponents/units/template/form/comments/comments.types";
-
-import { getServerTime } from "../../firebase";
 
 // 차단 관련 apis
 const blockApis = () => {

--- a/src/main/commonsComponents/units/template/form/comments/comments.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/comments.container.tsx
@@ -9,16 +9,10 @@ import blockApis from "src/commons/libraries/apis/block/block.apis";
 
 import {
   CollectionReferenceDocumentData,
-  getDoc,
   getResult,
-  QueryDocumentData,
 } from "src/commons/libraries/firebase";
 
-import {
-  initCountList,
-  initCommentsInfo,
-  CommentsAllInfoTypes,
-} from "./comments.types";
+import { initCommentsInfo, CommentsAllInfoTypes } from "./comments.types";
 import {
   deepCopy,
   getUserIp,
@@ -26,6 +20,7 @@ import {
 } from "src/main/commonsComponents/functional";
 import { checkAccessToken } from "src/main/commonsComponents/withAuth/check";
 import countApis from "src/commons/libraries/apis/comments/count/count.apis";
+import commentsApis from "src/commons/libraries/apis/comments/comments.apis";
 
 // 데이터 조회중 (중복 실행 방지)
 let wating = false;
@@ -54,73 +49,6 @@ export default function CommentsPage() {
     });
   }, [commentsInfo]);
 
-  // 필터 쿼리 적용하기
-  const getFilterQuery = ({
-    doc,
-    info,
-    notLimit,
-    startPage,
-  }: {
-    doc: QueryDocumentData;
-    info: CommentsAllInfoTypes;
-    notLimit?: boolean; // 전체 데이터로 가져오기
-    startPage?: number; // 시작용 페이지
-  }) => {
-    const { selectCategory, filter } = info;
-    const { list, limit, page } = filter;
-
-    // 선택되어 있는 카테고리가 있다면 해당 카테고리 조회
-    if (selectCategory !== "all" && selectCategory) {
-      doc = doc.where("category", "==", selectCategory);
-    }
-
-    switch (selectCategory) {
-      case "bug":
-        // 카테고리가 버그일 경우
-        if (list["bug-complete"])
-          // 해결 완료만 보기
-          doc = doc.where("bugStatus", "==", 2);
-        break;
-
-      case "question":
-        // 카테고리가 문의일 경우
-        if (list["question-complete"])
-          // 답변 완료만 보기
-          doc = doc.where("answer", "!=", "").orderBy("answer");
-        break;
-    }
-
-    // 카테고리가 버그 및 리뷰일 경우
-    if (selectCategory === "bug" || selectCategory === "review") {
-      const numArr = [];
-
-      // 선택한 점수들만 모아보기
-      for (const num in list) {
-        if (list[num]) {
-          const _rating = num.split("-");
-
-          if (_rating[0] === selectCategory && Number(_rating[1]))
-            numArr.push(Number(_rating[1]));
-        }
-      }
-
-      const column = selectCategory === "review" ? "rating" : "bugLevel";
-      // 해당 점수로 필터하기
-      if (numArr.length) doc = doc.where(column, "in", numArr);
-    }
-
-    // 삭제되지 않은 댓글만 조회
-    doc = doc.where("deletedAt", "==", null);
-
-    // 과거순 및 최신순으로 조회하기
-    doc = doc.orderBy("createdAt", list.oddest ? "asc" : "desc");
-
-    // 페이지 별로 데이터 limit 개씩 노출
-    if (!notLimit) doc = doc.limit(limit * page);
-
-    return doc;
-  };
-
   // 댓글 리스트 조회
   const fetchCommentsList = async (
     info?: CommentsAllInfoTypes,
@@ -131,27 +59,30 @@ export default function CommentsPage() {
     setLoading(true);
 
     if (module) {
-      const _info = deepCopy(info || commentsInfo);
+      const _info = deepCopy(info || commentsInfo) as CommentsAllInfoTypes;
+      const { selectCategory, filter } = _info;
+      const { list } = filter;
 
-      for (const filter in _info.filter.list) {
-        if (!_info.filter.list[filter]) {
-          _info.filter.list[filter] = false;
+      for (const filterInfo in list) {
+        if (!list[filterInfo]) {
+          list[filterInfo] = false;
         }
       }
-      const doc = getFilterQuery({
-        doc: getDoc("comments", module, "comment"),
-        info: _info,
-        startPage,
-      });
 
       try {
-        const result = await apis(
-          doc as CollectionReferenceDocumentData
-        ).read();
         const _commentInfo = deepCopy(_info) as CommentsAllInfoTypes;
 
-        // 댓글 리스트 저장하기
-        _commentInfo.commentsList = getResult(result);
+        // 댓글 리스트 저장하기 (필터 적용된 데이터로 조회)
+        _commentInfo.commentsList = getResult(
+          await apis(
+            (
+              await commentsApis({ module, ip: _info.userIp })
+            ).getQueryResult({
+              category: selectCategory,
+              filterList: filter,
+            }) as CollectionReferenceDocumentData
+          ).read()
+        );
 
         // 카테고리 개수 저장하기
         const getCountList = await countApis({ module }).asyncAllCountList(
@@ -181,13 +112,17 @@ export default function CommentsPage() {
           );
           if (filterBug.length) {
             // 모든 데이터 조회하기
-            const bugDoc = getFilterQuery({
-              doc: getDoc("comments", module, "comment"),
-              info: _info,
-              notLimit: true,
-            });
+            const getAllSize = await apis(
+              (
+                await commentsApis({ module })
+              ).getQueryResult({
+                category: _commentInfo.selectCategory,
+                filterList: _commentInfo.filter,
+                notLimit: true,
+              }) as CollectionReferenceDocumentData
+            ).read();
+            const allSize = getAllSize.size;
 
-            const allSize = (await bugDoc.get()).size;
             _commentInfo.filter.allData = allSize;
             _commentInfo.countFilterList[_commentInfo.selectCategory].count =
               allSize;
@@ -228,84 +163,6 @@ export default function CommentsPage() {
     setLoading(false);
   };
 
-  // 카테고리 개수 저장하기
-  const saveCategoryCount = async (info: CommentsAllInfoTypes) => {
-    return;
-
-    const filterCountList = deepCopy(info.countFilterList);
-
-    if (module) {
-      try {
-        const doc = getDoc("comments", module, "count");
-
-        const categoryList = await apis(doc).read();
-        if (categoryList.empty) {
-          // 비어있을 경우 새로 생성하기
-          Promise.all(
-            initCountList.map(async (el) => {
-              await (doc as CollectionReferenceDocumentData).add(el);
-            })
-          );
-        } else {
-          categoryList.forEach((data) => {
-            const _data = data.data();
-
-            // 각각의 카테고리 정보 가져오기
-            filterCountList[_data.category] = {
-              ...filterCountList[_data.category],
-              ..._data,
-            };
-            filterCountList[_data.category].id = data.id;
-
-            // count와 카테고리만 제외한 나머지 필터 키값만 가져오기
-            const { category } = _data;
-            // 현재 선택되어 있는 필터 정보 가져오기
-            const { list } = info.filter;
-
-            if (category === "question" && list["question-complete"]) {
-              // 카테고리가 문의이면서 완료된 항목만 검색할 경우
-              filterCountList[category].count = _data["question-complete"];
-            } else if (category === "review" || category === "bug") {
-              // 카테고리가 리뷰 또는 버그일 경우
-
-              if (category === "bug" && list["bug-complete"]) {
-                // 카테고리가 버그이면서 완료된 항목 검색시
-                filterCountList[category].count = _data["bug-complete"];
-              }
-
-              // 점수별로 필터가 있는지 검증
-              const isFilter = Array.from(
-                new Array(5),
-                (_, idx) => 1 + idx
-              ).some((num) => list[`${category}-${num}`]);
-
-              if (isFilter) {
-                // 필터 검증을 위해 전체 개수 초기화
-                filterCountList[category].count = 0;
-
-                // 필터가 하나라도 있는 경우
-                Array.from(new Array(5), (_, idx) => 1 + idx).forEach((num) => {
-                  if (info.filter.list[`${category}-${num}`]) {
-                    filterCountList[category].count +=
-                      _data[`${category}-${num}`];
-                  }
-                });
-              }
-            }
-          });
-          // 전체 개수 구하기
-          filterCountList.all.count = 0;
-          for (const category in filterCountList) {
-            filterCountList.all.count += filterCountList[category].count;
-          }
-        }
-      } catch (err) {
-        console.log(err);
-      }
-    }
-    return filterCountList;
-  };
-
   // 데이터 정보 변경하기
   const changeInfo = (info: CommentsAllInfoTypes) => {
     const _info = { ...commentsInfo, ...info };
@@ -314,7 +171,11 @@ export default function CommentsPage() {
 
     // 카테고리가 변경될 경우, 필터 리스트 초기화
     if (commentsInfo.selectCategory !== info.selectCategory) {
-      _info.filter.list = {};
+      const filterList: { [key: string]: boolean } = {};
+
+      // 과거순 필터 유지하기
+      if (commentsInfo.filter.list.oddest) filterList.oddest = true;
+      _info.filter.list = filterList;
     }
 
     fetchCommentsList(_info);

--- a/src/main/commonsComponents/units/template/form/comments/comments.types.ts
+++ b/src/main/commonsComponents/units/template/form/comments/comments.types.ts
@@ -35,6 +35,7 @@ export const initCountList: Array<{ [key: string]: number | string }> = [
   {
     category: "bug",
     count: 0,
+    deleted: 0,
     "bug-complete": 0,
     "bug-1": 0,
     "bug-2": 0,
@@ -42,10 +43,11 @@ export const initCountList: Array<{ [key: string]: number | string }> = [
     "bug-4": 0,
     "bug-5": 0,
   },
-  { category: "question", count: 0, "question-complete": 0 },
+  { category: "question", count: 0, deleted: 0, "question-complete": 0 },
   {
     category: "review",
     count: 0,
+    deleted: 0,
     "review-1": 0,
     "review-2": 0,
     "review-3": 0,
@@ -65,15 +67,30 @@ export interface BlockInfoTypes {
   module?: string;
   isBlock: boolean;
 }
-interface CountFilterCommonsType {
+export interface CountFilterCommonsType {
   count: number;
   category: string;
   id: string;
+  deleted: number; // 삭제된 댓글 수
 }
+
+export type CountFilterTypes = {
+  // 카테고리별 전체 개수 및 필터별 개수
+  all: CountFilterCommonsType | { [key: string]: number };
+  bug: CountFilterCommonsType | { [key: string]: number };
+  question: CountFilterCommonsType | { [key: string]: number };
+  review: CountFilterCommonsType | { [key: string]: number };
+} & {
+  [key: string]:
+    | { [key: string]: number & string }
+    | CountFilterCommonsType
+    | (number & string);
+};
 
 export interface CommentsAllInfoTypes {
   commentsList: Array<InfoTypes>;
   selectCategory: CategoryTypes | string;
+  selectModule: string;
   filter:
     | {
         // search: string; // 검색어
@@ -94,19 +111,7 @@ export interface CommentsAllInfoTypes {
       };
   blockInfo: BlockInfoTypes; // 차단된 유저라면 해당 사유 및 아이피 저장
   userIp: string; // 유저 아이피 저장
-  countFilterList:
-    | {
-        // 카테고리별 전체 개수 및 필터별 개수
-        all: CountFilterCommonsType | { [key: string]: number };
-        bug: CountFilterCommonsType | { [key: string]: number };
-        question: CountFilterCommonsType | { [key: string]: number };
-        review: CountFilterCommonsType | { [key: string]: number };
-      } & {
-        [key: string]:
-          | { [key: string]: number }
-          | CountFilterCommonsType
-          | (number & string);
-      };
+  countFilterList: CountFilterTypes;
 }
 
 export type CommentsPartialPropsType = Partial<CommentsAllInfoTypes>;
@@ -115,6 +120,7 @@ export type CommentsPartialPropsType = Partial<CommentsAllInfoTypes>;
 export const initCommentsInfo: CommentsAllInfoTypes = {
   commentsList: [], // 댓글 리스트
   selectCategory: "all", // 선택된 카테고리
+  selectModule: "", // 선택된 모듈
   filter: {
     allData: 0,
     limit: 10,
@@ -126,9 +132,9 @@ export const initCommentsInfo: CommentsAllInfoTypes = {
   blockInfo: { isBlock: false },
   userIp: "",
   countFilterList: {
-    all: { count: 0, category: "all", id: "" },
-    bug: { count: 0, category: "bug", id: "" },
-    question: { count: 0, category: "question", id: "" },
-    review: { count: 0, category: "review", id: "" },
+    all: { count: 0, deleted: 0, category: "all", id: "" },
+    bug: { count: 0, deleted: 0, category: "bug", id: "" },
+    question: { count: 0, deleted: 0, category: "question", id: "" },
+    review: { count: 0, deleted: 0, category: "review", id: "" },
   },
 };

--- a/src/main/commonsComponents/units/template/form/comments/list/comments.list.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/comments.list.container.tsx
@@ -1,5 +1,5 @@
 import { deepCopy } from "src/main/commonsComponents/functional";
-import { InfoTypes, CommentsAllInfoTypes } from "../comments.types";
+import { CommentsAllInfoTypes } from "../comments.types";
 import CommentsListUIPage from "./comments.list.presenter";
 
 import { MutableRefObject, useEffect, useRef } from "react";

--- a/src/main/commonsComponents/units/template/form/comments/list/comments.list.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/comments.list.presenter.tsx
@@ -19,7 +19,7 @@ import { getUuid } from "src/main/commonsComponents/functional";
 
 import ListContentsInfoPage from "./contents/list.contents.container";
 import CommentsFilterPage from "./filter";
-import _PaginationForm from "../../pagination";
+// import _PaginationForm from "../../pagination";
 
 export default function CommentsListUIPage({
   commentsInfo,
@@ -57,7 +57,6 @@ export default function CommentsListUIPage({
 
               // 선택 불가능한 카테고리인지? (개수가 0개일 때)
               const isDisable = categoryLen === 0;
-
               return (
                 <Category
                   key={`comments-category-list-${name}-${key}`}
@@ -89,10 +88,7 @@ export default function CommentsListUIPage({
 
       {!commentsInfo.commentsList.length ? (
         <EmptyWrapper>
-          <_PText className="empty-list">
-            등록된 댓글이 없습니다. <br />
-            제일 먼저 댓글을 등록해보세요!
-          </_PText>
+          <_PText className="empty-list">조회된 댓글이 없습니다.</_PText>
         </EmptyWrapper>
       ) : (
         <CommentListItems ref={listRef}>

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.container.tsx
@@ -193,8 +193,9 @@ export default function ContentsSelectFunctionalPage({
         }
       }
 
+      const { ip, contents, category, id } = info;
       const commentApi = await commentsApis({
-        input: info as WriteInfoTypes,
+        ip,
         module,
         isAdmin: adminLogin || false,
       });
@@ -203,6 +204,7 @@ export default function ContentsSelectFunctionalPage({
       if (typeName === "삭제" || typeName === "차단") {
         // 기존에 있던 데이터에 업데이트
         const { msg } = await commentApi.removeComments({
+          input: info as WriteInfoTypes,
           password,
           updateCategory: true,
         });
@@ -210,7 +212,6 @@ export default function ContentsSelectFunctionalPage({
         // 해당 유저 차단
         if (typeName === "차단") {
           try {
-            const { ip, contents, category, id } = info;
             await blockApis().block({
               ip,
               contents,

--- a/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/contents/select/functional/contents.select.functional.presenter.tsx
@@ -11,7 +11,7 @@ import {
   BugStatusButton,
 } from "./contents.select.functional.styles";
 
-import { _Title, _Input, _Button, _SpanText } from "mcm-js-commons";
+import { _Title, _Input } from "mcm-js-commons";
 import { InfoTypes } from "../../../../comments.types";
 import { Tooltip } from "mcm-js";
 

--- a/src/main/commonsComponents/units/template/form/comments/list/filter/index.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/filter/index.tsx
@@ -32,11 +32,18 @@ export default function CommentsFilterPage({
     ...filterInitList,
   ]);
 
+  // 필터 비활성화 여부
+  let isDisable = !commentsList.length; // 조회된 데이터가 하나도 없는 경우
+  if (Object.values(commentsInfo.filter.list).some((el) => el)) {
+    // 필터가 현재 하나라도 적용되어 있는 경우
+    isDisable = false;
+  }
+
   useEffect(() => {
     // 카테고리가 변경될 경우 필터 변경하기
     let _filterList = [...filterInitList];
 
-    if (commentsList.length) {
+    if (!isDisable) {
       if (categoryFilterList[selectCategory]) {
         // 해당 카테고리에서만 사용 가능한 필터가 존재할 경우
         // 기존의 필터리스트에 추가
@@ -94,8 +101,7 @@ export default function CommentsFilterPage({
 
   // 필터창 오픈 및 닫기
   const toggleFilter = (bool?: boolean) => {
-    if (commentsList.length)
-      setOpen(bool !== undefined ? bool : (prev) => !prev);
+    if (!isDisable) setOpen(bool !== undefined ? bool : (prev) => !prev);
   };
 
   // 필터 정보 변경하기
@@ -145,7 +151,7 @@ export default function CommentsFilterPage({
         <FilterButton
           onClickEvent={() => toggleFilter()}
           className="filter-button"
-          disable={!commentsList.length}
+          disable={isDisable}
         >
           <_Image src={getFilterImage()} className="filter-image" />
         </FilterButton>
@@ -157,10 +163,11 @@ export default function CommentsFilterPage({
           {filterList.map((el) => {
             const isSelected = filter.list[el.target] || false;
             // @ts-ignore
-            const count = countFilterList[selectCategory][el.target];
+            const count = countFilterList[selectCategory][el.target] || "";
 
             // 필터의 개수가 0개인지 검증
-            let isEmpty = count === 0;
+            const isEmpty =
+              count === 0 || (count === "" && !el.searchFilterList);
 
             return (
               <FilterList

--- a/src/main/commonsComponents/units/template/form/comments/list/label/index.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/label/index.tsx
@@ -3,13 +3,11 @@ import { Label, LabelWrapper, UserIP } from "./label.styles";
 import { _Button } from "mcm-js-commons";
 import React, { MouseEvent } from "react";
 
-// import CommonsHooksComponents from "src/main/commonsComponents/hooks/commonsHooks";
 import { CommentsAllInfoTypes, InfoTypes } from "../../comments.types";
 import { getUuid } from "src/main/commonsComponents/functional";
 
 import { categoryInitList } from "../../write/comments.write.types";
 import StarsForm from "../../write/stars";
-import { AdminCommentsInitType } from "src/main/mainComponents/admin/modules/comments/admin.comments.types";
 
 // label 렌더용 컴포넌트
 export default function CommentsLabel({

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.container.tsx
@@ -221,8 +221,11 @@ export default function CommentsWritePage({
       if (input.category !== "review") input.rating = 0;
 
       // 댓글 추가하기
-      const addDocs = await commentsApis({ module, input });
-      const addResult = await addDocs.addComments(true);
+      const addDocs = await commentsApis({ module, ip: input.ip });
+      const addResult = await addDocs.addComments({
+        input,
+        updateCategory: true,
+      });
 
       const _info = { ...commentsInfo };
 

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.presenter.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.presenter.tsx
@@ -8,7 +8,7 @@ import {
   WriteButton,
 } from "./comments.write.styles";
 
-import { _Input, _PText, _PTextWithHtml, _SpanText } from "mcm-js-commons";
+import { _Input } from "mcm-js-commons";
 import { IPropsTypes } from "./comments.write.types";
 
 import StarsForm from "./stars";

--- a/src/main/commonsComponents/units/template/form/comments/write/comments.write.types.ts
+++ b/src/main/commonsComponents/units/template/form/comments/write/comments.write.types.ts
@@ -2,7 +2,6 @@ import { FormEvent, MutableRefObject } from "react";
 
 import { FieldValue } from "src/commons/libraries/firebase";
 import { BlockInfoTypes, CommentsInfoTypes } from "../comments.types";
-import { IsBlockTypes } from "src/commons/store/store.types";
 
 // 작성용 type
 export type WriteInfoTypes = {

--- a/src/main/mainComponents/admin/login/admin.login.presenter.tsx
+++ b/src/main/mainComponents/admin/login/admin.login.presenter.tsx
@@ -60,7 +60,7 @@ export default function AdminLoginUIPage({
             />
             <ShowPw buttonType="button" onClickEvent={toggleShowPw}>
               <Tooltip tooltipText={`비밀번호 ${showPw ? "가리기" : "보이기"}`}>
-                {showPw ? "🙈" : "🙉"}
+                {!showPw ? "🙈" : "🙉"}
               </Tooltip>
             </ShowPw>
           </InputItems>

--- a/src/main/mainComponents/admin/modules/comments/admin.comments.presenter.tsx
+++ b/src/main/mainComponents/admin/modules/comments/admin.comments.presenter.tsx
@@ -8,6 +8,7 @@ import {
   PaginationWrapper,
   PaginationItems,
   CategoryFilterWrapper,
+  CommentsOptionWrapper,
 } from "./admin.comments.styles";
 import { _Title, _Button, _Image } from "mcm-js-commons";
 
@@ -31,14 +32,13 @@ export default function AdminCommentsUIPage({
   info,
   isLoading,
   changeSelectModule,
-  render,
   changeLoading,
   fetchComments,
-  changeInfo,
   toggleSettings,
   oepnSettings,
   checkLoading,
   changePage,
+  changeFilterComments,
 }: AdminCommentsPropsType) {
   // 관리자 기능 props 객체
   const functionProps: FunctionPropsTypes = {
@@ -62,50 +62,55 @@ export default function AdminCommentsUIPage({
           </LoadingWrapper>
         )) || <></>}
         <Items isLoading={isLoading || false}>
-          <ModuleSelectWrapper>
-            <ModuleSelector
-              onChange={changeSelectModule}
-              defaultValue={info.selectModule}
-            >
-              {navList &&
-                navList.length &&
-                navList.map((module, idx) => (
-                  <option
-                    key={`admin-module-${module.name}-${idx}`}
-                    disabled={module.name === info.selectModule}
-                  >
-                    {module.name}
-                  </option>
-                ))}
-            </ModuleSelector>
-            <AdminFunctionalWrapper>
-              <_Button onClickEvent={toggleSettings(true)}>
-                <_Image
-                  src={`/images/commons/icons/settings${
-                    (oepnSettings && "-on") || ""
-                  }.png`}
-                  className="settings-icon"
-                />
-              </_Button>
-              <_SelectForm
-                show={oepnSettings}
-                closeEvent={toggleSettings(false)}
-                className="admin-function-select"
+          <CommentsOptionWrapper>
+            <ModuleSelectWrapper>
+              <ModuleSelector
+                onChange={changeSelectModule}
+                defaultValue={info.selectModule}
               >
-                <ExtendsFunction {...functionProps} />
-                <SyncComments {...functionProps} />
-              </_SelectForm>
-            </AdminFunctionalWrapper>
-          </ModuleSelectWrapper>
-
-          <CategoryFilterWrapper>
-            <AdminCommentsCategoryPage
-              info={info}
-              changeInfo={changeInfo}
-              render={render}
-            />
-            {/* <CommentsFilterPage commentsInfo={info} /> */}
-          </CategoryFilterWrapper>
+                {navList &&
+                  navList.length &&
+                  navList.map((module, idx) => (
+                    <option
+                      key={`admin-module-${module.name}-${idx}`}
+                      disabled={module.name === info.selectModule}
+                    >
+                      {module.name}
+                    </option>
+                  ))}
+              </ModuleSelector>
+              <AdminFunctionalWrapper>
+                <_Button onClickEvent={toggleSettings(true)}>
+                  <_Image
+                    src={`/images/commons/icons/settings${
+                      (oepnSettings && "-on") || ""
+                    }.png`}
+                    className="settings-icon"
+                  />
+                </_Button>
+                <_SelectForm
+                  show={oepnSettings}
+                  closeEvent={toggleSettings(false)}
+                  className="admin-function-select"
+                >
+                  <ExtendsFunction {...functionProps} />
+                  <SyncComments {...functionProps} />
+                </_SelectForm>
+              </AdminFunctionalWrapper>
+            </ModuleSelectWrapper>
+            <CategoryFilterWrapper>
+              <AdminCommentsCategoryPage
+                info={info}
+                changeLoading={changeLoading}
+                fetchComments={fetchComments}
+              />
+              <CommentsFilterPage
+                commentsInfo={info}
+                changeInfo={changeFilterComments}
+                isAdmin
+              />
+            </CategoryFilterWrapper>
+          </CommentsOptionWrapper>
 
           <AdminCommentsListPage
             info={info}

--- a/src/main/mainComponents/admin/modules/comments/admin.comments.styles.ts
+++ b/src/main/mainComponents/admin/modules/comments/admin.comments.styles.ts
@@ -46,7 +46,7 @@ export const LoadingWrapper = styled.div`
   width: 100%;
   height: 100%;
   z-index: 100;
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: rgba(255, 255, 255, 0.6);
   border-radius: 10px;
   display: flex;
   align-items: center;
@@ -96,4 +96,14 @@ export const CategoryFilterWrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-top: 20px;
+  width: 100%;
+`;
+
+export const CommentsOptionWrapper = styled.div`
+  position: sticky;
+  top: 0px;
+  background-color: white;
+  z-index: 100;
+  border-bottom: double 4px black;
+  padding-bottom: 30px;
 `;

--- a/src/main/mainComponents/admin/modules/comments/admin.comments.types.ts
+++ b/src/main/mainComponents/admin/modules/comments/admin.comments.types.ts
@@ -1,28 +1,35 @@
 import { ChangeEvent } from "react";
 import { CommentsAllInfoTypes } from "src/main/commonsComponents/units/template/form/comments/comments.types";
 
-export type AdminCommentsInitType = CommentsAllInfoTypes & {
-  selectModule: string;
+export type FetchCommentsTypes = {
+  fetchComments: ({
+    info,
+    isInfinite,
+    alertMsg,
+    moveTop,
+  }: {
+    info?: CommentsAllInfoTypes;
+    isInfinite?: boolean;
+    alertMsg?: string;
+    moveTop?: boolean;
+  }) => Promise<void>;
 };
 
-export interface AdminCommentsPropsType {
-  info: AdminCommentsInitType;
+export type AdminCommentsPropsType = {
+  info: CommentsAllInfoTypes;
   isLoading: boolean;
   changeSelectModule: (e: ChangeEvent<HTMLSelectElement>) => void;
-  render: boolean;
   changeLoading: (bool: boolean) => void;
-  fetchComments: (info?: AdminCommentsInitType) => void;
-  changeInfo: (info: AdminCommentsInitType, forcing?: boolean) => void;
   toggleSettings: (bool: boolean) => () => void;
   oepnSettings: boolean;
   checkLoading: () => boolean;
   changePage: (page: number, isInfinite?: boolean) => void;
-}
+  changeFilterComments: (info: CommentsAllInfoTypes) => void;
+} & FetchCommentsTypes;
 
-export interface FunctionPropsTypes {
+export type FunctionPropsTypes = {
   module: string;
   changeLoading: (bool: boolean) => void;
-  info: AdminCommentsInitType;
-  fetchComments: (info?: AdminCommentsInitType) => void;
+  info: CommentsAllInfoTypes;
   checkLoading: () => boolean;
-}
+} & FetchCommentsTypes;

--- a/src/main/mainComponents/admin/modules/comments/category/admin.comments.category.tsx
+++ b/src/main/mainComponents/admin/modules/comments/category/admin.comments.category.tsx
@@ -2,25 +2,35 @@ import styled from "@emotion/styled";
 import { _Button } from "mcm-js-commons";
 
 import { categoryListArray } from "src/main/commonsComponents/units/template/form/comments/write/comments.write.types";
-import { AdminCommentsInitType } from "../admin.comments.types";
+import { CommentsAllInfoTypes } from "src/main/commonsComponents/units/template/form/comments/comments.types";
+import { FetchCommentsTypes } from "../admin.comments.types";
 
 const categoryList = [...categoryListArray];
 export default function AdminCommentsCategoryPage({
   info,
-  changeInfo,
-}: // render,
-{
-  info: AdminCommentsInitType;
-  changeInfo: (info: AdminCommentsInitType) => void;
-  render: boolean;
-}) {
+  fetchComments,
+  changeLoading,
+}: {
+  info: CommentsAllInfoTypes;
+  changeLoading: (bool: boolean) => void;
+} & FetchCommentsTypes) {
+  const { countFilterList, selectCategory, selectModule } = info;
+
   // 카테고리 변경하기
   const changeCategory = (category: string) => {
     const _info = { ...info, ["selectCategory"]: category };
     _info.filter.page = 1;
     _info.filter.startPage = 0;
 
-    changeInfo(_info);
+    const filterList: { [key: string]: boolean } = {};
+    // 과거순 보기 유지
+    if (_info.filter.list.oddest) filterList.oddest = true;
+    // 삭제된 댓글 보기 유지
+    if (_info.filter.list.deleted) filterList.deleted = true;
+    _info.filter.list = filterList;
+
+    changeLoading(true);
+    fetchComments({ info: _info, moveTop: true });
   };
 
   return (
@@ -29,10 +39,10 @@ export default function AdminCommentsCategoryPage({
         {categoryList &&
           categoryList.map((category, idx) => {
             const data = Object.entries(category)[0];
-            const isSelected = info.selectCategory === data[0];
+            const isSelected = selectCategory === data[0];
 
             // 해당 카테고리의 전체 데이터 수
-            let categoryLen = info[data[0]] || 0;
+            let categoryLen = countFilterList[data[0]].count || 0;
             if (categoryLen > 999) categoryLen = 999;
 
             return (
@@ -41,7 +51,7 @@ export default function AdminCommentsCategoryPage({
                   (!isSelected && categoryLen && changeCategory(data[0])) ||
                   undefined
                 }
-                key={`admin-comments-${info.selectModule}-category-${data[0]}-${data[1]}-${idx}`}
+                key={`admin-comments-${selectModule}-category-${data[0]}-${data[1]}-${idx}`}
                 isSelected={isSelected}
                 isEmpty={categoryLen === 0}
               >
@@ -62,7 +72,6 @@ interface StyleTypes {
 export const CategoryWrapper = styled.div`
   display: flex;
   height: 20px;
-  width: 100%;
 `;
 
 export const CategoryListContents = styled.div`

--- a/src/main/mainComponents/admin/modules/comments/function/extends/index.tsx
+++ b/src/main/mainComponents/admin/modules/comments/function/extends/index.tsx
@@ -13,9 +13,7 @@ import {
   getUserIp,
 } from "src/main/commonsComponents/functional";
 import { randomContents } from "./data";
-import { InitTypes } from "src/main/commonsComponents/units/template/form/comments/list/filter/filter.init";
 import countApis from "src/commons/libraries/apis/comments/count/count.apis";
-import { initCountList } from "src/main/commonsComponents/units/template/form/comments/comments.types";
 
 // 테스트용을 위한 임의의 댓글 게시물 생성하기
 export default function ExtendsFunction(props: FunctionPropsTypes) {
@@ -25,7 +23,7 @@ export default function ExtendsFunction(props: FunctionPropsTypes) {
   const extendsComments = async () => {
     if (!checkLoading()) return;
 
-    let num = Number(
+    const num = Number(
       window.prompt(
         "몇개의 댓글을 생성하시겠습니까? \n(최대 30개까지 생성 가능)"
       ) || 0
@@ -36,7 +34,7 @@ export default function ExtendsFunction(props: FunctionPropsTypes) {
         const ip = await getUserIp();
 
         // 전체 카테고리 초기값 객체
-        let allCountList = await countApis({ module }).getAllCountList();
+        const allCountList = await countApis({ module }).getAllCountList();
 
         const createComments = async (
           i: number,
@@ -69,7 +67,7 @@ export default function ExtendsFunction(props: FunctionPropsTypes) {
           }
 
           // 댓글 등록하기
-          (await commentsApis({ module, input })).addComments();
+          (await commentsApis({ module, ip: input.ip })).addComments({ input });
 
           // 해당 카테고리에 맞는 카운트 객체 가져오기
           const currentList = allCountList[input.category];
@@ -105,44 +103,12 @@ export default function ExtendsFunction(props: FunctionPropsTypes) {
             alert(`${num}개의 댓글이 추가되었습니다.`);
 
             changeLoading(false);
-            fetchComments(info);
+            fetchComments({ info });
           })
           .catch((err) => {
             alert("동기화에 실패했습니다.");
             console.log(err);
           });
-
-        //   // 업데이트 된 리스트 저장하기
-        //   allCountList[countAddResult.countList.category] =
-        //     countAddResult.countList;
-        //   })
-        // );
-
-        // if (addCommentsList.length) {
-        //   addCommentsList.forEach(async (el) => {
-        //     console.log(allCountList, el);
-        //     console.log(allCountList[el.category]);
-        //     console.log(
-        //       await countApis({ module }).add({
-        //         input: el,
-        //         countList: allCountList,
-        //       })
-        //     );
-        //   });
-        // }
-
-        // 댓글들 병렬로 등록하기
-        // await Promise.all(promiseAll);
-
-        // 카테고리 카운트 병렬 처리하기
-        // const promiseAllCountList = Object.values(allCountList).map(
-        //   async (el) => {
-        //     const { id, ...countList } = el;
-
-        //     await countApis({ module }).update(id, countList);
-        //   }
-        // );
-        // await Promise.all(promiseAllCountList);
       } catch (err) {
         alert("댓글 추가에 실패했습니다.");
         console.log(err);

--- a/src/main/mainComponents/admin/modules/comments/function/sync/index.tsx
+++ b/src/main/mainComponents/admin/modules/comments/function/sync/index.tsx
@@ -1,12 +1,15 @@
 import { _Button } from "mcm-js-commons";
+import { FunctionPropsTypes } from "../../admin.comments.types";
+import { deepCopy } from "src/main/commonsComponents/functional";
 
-import { getDoc } from "src/commons/libraries/firebase";
+import countApis from "src/commons/libraries/apis/comments/count/count.apis";
+import { getDoc, getResult } from "src/commons/libraries/firebase";
+
 import {
   InfoTypes,
   initCountList,
 } from "src/main/commonsComponents/units/template/form/comments/comments.types";
-import { FunctionPropsTypes } from "../../admin.comments.types";
-import { deepCopy } from "src/main/commonsComponents/functional";
+import { checkAccessToken } from "src/main/commonsComponents/withAuth/check";
 
 // 댓글 정보와 개수 최신화 업데이트
 export default function SyncCommentsFunction(props: FunctionPropsTypes) {
@@ -14,104 +17,92 @@ export default function SyncCommentsFunction(props: FunctionPropsTypes) {
 
   // 개수 최신화하기
   const syncComments = async () => {
-    if (!checkLoading()) return;
+    if (!checkLoading() || !checkAccessToken(true)) return;
 
     if (window.confirm("댓글 동기화 작업을 실행하시겠습니까?")) {
+      const _info = deepCopy(info);
+      const { countFilterList } = _info;
+
       try {
         changeLoading(true);
 
         // 전체 데이터 가져오기 (삭제된 게시물 제외)
-        const commentsList = (
+        const commentsList = getResult(
           await getDoc("comments", module, "comment")
             .where("deletedAt", "==", null)
             .get()
-        ).docs;
+        );
 
         // 현재 모듈의 카운트 리스트 가져오기
-        const countList: { [key: string]: number } = deepCopy(info.countList);
+        const countList = deepCopy(countFilterList);
         // 모든 개수 초기화
-        for (const key in countList) {
-          countList[key] = 0;
-        }
-
-        // 필터 정보도 함께 가져오기
-        const filterCountList: {
-          [key: string]: { [key: string]: number };
-        } = {};
-
-        // 모든 필터 개수 초기화
         initCountList.forEach((el) => {
-          const { category, count, ...filterList } = el;
-          // @ts-ignore
-          filterCountList[category] = filterList;
+          const { category } = el;
+          countList[category] = { ...el, id: countList[category].id };
         });
 
-        if (commentsList && commentsList.length) {
-          commentsList.forEach((el) => {
-            const data = el.data() as InfoTypes;
+        // 전체 개수 담기
+        countList.all.count = commentsList.length;
 
-            countList.all++; // 전체 데이터 수 1개 증가
-            countList[data.category]++; // 해당 카테고리 수 1개 증가
+        // 카테고리 개수 종합하기
+        commentsList.forEach((el: InfoTypes) => {
+          const { category, answer, answerCreatedAt, bugStatus } = el;
 
-            if (data.category === "bug") {
-              // 카테고리가 이슈일 경우
-              if (data.bugStatus === 2) {
-                // 수정이 완료된 경우
-                filterCountList.bug["bug-complete"]++;
-              }
-              // 해당 버그 레벨 1개 증가
-              if (data.bugLevel) filterCountList.bug[`bug-${data.bugLevel}`]++;
-            } else if (data.category === "question") {
-              // 카테고리가 문의일 경우
-              if (data.answer && data.answerCreatedAt) {
-                // 답변이 완료된 경우
-                filterCountList.question["question-complete"]++;
-              }
-            } else if (data.category === "review") {
-              // 카테고리가 리뷰일 경우, 해당 리뷰 점수 1개 증가
-              if (data.rating)
-                filterCountList.review[`review-${data.rating}`]++;
+          // 해당 카테고리의 개수 1개 더하기
+          countList[category].count++;
+
+          if (category === "question") {
+            if (answer && answerCreatedAt) {
+              // 카테고리가 문의이면서, 답변이 등록되어 있는 경우
+              countList.question["question-complete"]++;
             }
-          });
-        }
+          } else {
+            // 카테고리가 이슈 또는 리뷰일 경우
+            const target = category === "bug" ? "bugLevel" : "rating";
+            const num = el[target];
+
+            // 해당 점수의 카테고리 개수 1개 증가
+            countList[category][`${category}-${num}`]++;
+
+            if (category === "bug" && bugStatus === 2) {
+              // 버그 카테고리이면서, 해결이 완료된 경우
+              countList.bug["bug-complete"]++;
+            }
+          }
+        });
+
+        // 전체 개수와 비교했을 때 일치하지 않는다면 새로 갱신
+        const tempAllData =
+          countList.bug.count +
+          countList.question.count +
+          countList.review.count;
+        if (countList.all.count !== tempAllData)
+          countList.all.count = tempAllData;
 
         try {
-          const countListDoc = getDoc("comments", module, "count");
+          // 카테고리 서버에 저장하기
+          await Promise.all(
+            Object.entries(countList).filter(async (el) => {
+              const categoryName: string = el[0];
+              // @ts-ignore
+              const { id, ...list } = el[1];
 
-          // 서버에 데이터 저장하기
-          const fetchCountListResult = (await countListDoc.get()).docs;
-          if (fetchCountListResult && fetchCountListResult.length) {
-            await Promise.all(
-              fetchCountListResult.map((el) => {
-                let { category } = el.data();
-                const id = el.id; // doc id값 저장
+              _info.countFilterList[categoryName] = list;
 
-                const changeInfo = {
-                  category,
-                  count: countList[category],
-                  ...filterCountList[category],
-                };
-
-                countListDoc.doc(id).update(changeInfo);
-              })
-            );
-
-            const _info = { ...info };
-            _info.countList = countList;
-            // @ts-ignore
-            _info.countFilterList = filterCountList;
-
-            fetchComments(_info);
-            alert("동기화가 완료되었습니다.");
-            changeLoading(false);
-          }
+              // 최종 업데이트
+              return await countApis({ module }).update(id, list);
+            })
+          );
         } catch (err2) {
-          alert("댓글 개수 데이터 조회에 실패했습니다.");
           console.log(err2);
+          alert("카테고리 업데이트에 실패했습니다.");
         }
+        fetchComments({ info: _info });
+        alert("동기화가 완료되었습니다.");
+        changeLoading(false);
       } catch (err) {
-        alert("댓글 데이터 조회에 실패했습니다.");
         console.log(err);
+        alert("댓글 리스트 조회에 실패했습니다.");
       }
     }
   };

--- a/src/main/mainComponents/admin/modules/comments/list/admin.comments.list.tsx
+++ b/src/main/mainComponents/admin/modules/comments/list/admin.comments.list.tsx
@@ -1,18 +1,18 @@
 import styled from "@emotion/styled";
-import { _Title, _SpanText, _Button, _PTextWithHtml } from "mcm-js-commons";
+import { _Title } from "mcm-js-commons";
 
-import { AdminCommentsInitType } from "../admin.comments.types";
+import { FetchCommentsTypes } from "../admin.comments.types";
 import AdminCommentsDetailPage from "./detail/admin.comments.detail.container";
+import { CommentsAllInfoTypes } from "src/main/commonsComponents/units/template/form/comments/comments.types";
 
 export default function AdminCommentsListPage({
   info,
   changeLoading,
   fetchComments,
 }: {
-  info: AdminCommentsInitType;
+  info: CommentsAllInfoTypes;
   changeLoading: (bool: boolean) => void;
-  fetchComments: (info?: AdminCommentsInitType) => void;
-}) {
+} & FetchCommentsTypes) {
   const { commentsList, selectModule, selectCategory } = info;
   const isEmpty = commentsList.length === 0;
 
@@ -47,8 +47,7 @@ export interface StyleTypes {
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  margin-top: 30px;
-  border-top: double 4px black;
+  /* border-top: double 4px black; */
   /* border-bottom: solid 3px black; */
 
   ${(props: StyleTypes) =>

--- a/src/main/mainComponents/admin/modules/comments/list/detail/admin.comments.detail.container.tsx
+++ b/src/main/mainComponents/admin/modules/comments/list/detail/admin.comments.detail.container.tsx
@@ -1,17 +1,10 @@
 import AdminCommentsDetailUIPage from "./admin.comments.detail.presenter";
-import {
-  _SpanText,
-  _Button,
-  _PTextWithHtml,
-  _SpanTextWithHtml,
-  _Input,
-} from "mcm-js-commons";
 
 import {
   CommentsAllInfoTypes,
   InfoTypes,
 } from "src/main/commonsComponents/units/template/form/comments/comments.types";
-import { AdminCommentsInitType } from "../../admin.comments.types";
+import { FetchCommentsTypes } from "../../admin.comments.types";
 import { WriteInfoTypes } from "src/main/commonsComponents/units/template/form/comments/write/comments.write.types";
 
 import blockApis from "src/commons/libraries/apis/block/block.apis";
@@ -25,10 +18,9 @@ export default function AdminCommentsDetailPage({
   fetchComments,
 }: {
   info: InfoTypes;
-  commentsInfo: CommentsAllInfoTypes & AdminCommentsInitType;
+  commentsInfo: CommentsAllInfoTypes;
   changeLoading: (bool: boolean) => void;
-  fetchComments: (info?: AdminCommentsInitType) => void;
-}) {
+} & FetchCommentsTypes) {
   // 이미 삭제된 댓글인지 체크
   const isAlreadyDeleted = info.deletedAt !== null;
 
@@ -44,6 +36,7 @@ export default function AdminCommentsDetailPage({
       msg = "해당 유저를 차단하시겠습니까? \n댓글은 자동으로 삭제됩니다.";
 
     if (window.confirm(msg)) {
+      changeLoading(true);
       const _info: WriteInfoTypes = { ...(info as WriteInfoTypes) };
       let ableBlock = isBlock; // 차단 가능 여부
 
@@ -52,10 +45,11 @@ export default function AdminCommentsDetailPage({
         const removeResult = await (
           await commentsApis({
             module: commentsInfo.selectModule,
-            input: _info,
+            ip: _info.ip,
             isAdmin: true,
           })
         ).removeComments({
+          input: _info,
           password: "",
           updateCategory: true,
         });
@@ -89,12 +83,13 @@ export default function AdminCommentsDetailPage({
           }
         }
 
-        alert(
-          isBlock && ableBlock
-            ? "차단이 완료되었습니다."
-            : "댓글 삭제가 완료되었습니다."
-        );
-        fetchComments(commentsInfo);
+        fetchComments({
+          info: commentsInfo,
+          alertMsg:
+            isBlock && ableBlock
+              ? "차단이 완료되었습니다."
+              : "댓글 삭제가 완료되었습니다.",
+        });
       } catch (err) {
         console.log(err);
         alert(`${isBlock ? "유저 차단" : "댓글 삭제"}에 실패했습니다.`);

--- a/src/main/mainComponents/admin/modules/comments/list/detail/admin.comments.detail.presenter.tsx
+++ b/src/main/mainComponents/admin/modules/comments/list/detail/admin.comments.detail.presenter.tsx
@@ -17,7 +17,7 @@ import {
   CommentsAllInfoTypes,
   InfoTypes,
 } from "src/main/commonsComponents/units/template/form/comments/comments.types";
-import { AdminCommentsInitType } from "../../admin.comments.types";
+import { FetchCommentsTypes } from "../../admin.comments.types";
 
 export default function AdminCommentsDetailUIPage({
   info,
@@ -28,12 +28,11 @@ export default function AdminCommentsDetailUIPage({
   fetchComments,
 }: {
   info: InfoTypes;
-  commentsInfo: CommentsAllInfoTypes & AdminCommentsInitType;
+  commentsInfo: CommentsAllInfoTypes;
   isAlreadyDeleted: boolean;
   removeComments: (isBlock: boolean) => void;
   changeLoading: (bool: boolean) => void;
-  fetchComments: () => void;
-}) {
+} & FetchCommentsTypes) {
   return (
     <ListDetailWrapper>
       <ListHeaderWrapper>

--- a/src/main/mainComponents/admin/modules/comments/list/detail/admin.comments.detail.styles.ts
+++ b/src/main/mainComponents/admin/modules/comments/list/detail/admin.comments.detail.styles.ts
@@ -47,5 +47,6 @@ export const RemoveButton = styled(_Button)`
     props.alreadyDeleted && {
       cursor: "default",
       fontWeight: 700,
+      color: "#aa5656",
     }}
 `;

--- a/src/main/mainComponents/admin/modules/comments/list/detail/contents/admin.comments.contents.container.tsx
+++ b/src/main/mainComponents/admin/modules/comments/list/detail/contents/admin.comments.contents.container.tsx
@@ -2,12 +2,11 @@ import { OptionList, OptionBtn } from "./admin.comments.contents.styles";
 import { MouseEvent, MutableRefObject, useRef } from "react";
 import AdminCommentsContentsUIPage from "./admin.comments.contents.presenter";
 
-import { _Input, _SpanText, _Button } from "mcm-js-commons";
 import {
   CommentsAllInfoTypes,
   InfoTypes,
 } from "src/main/commonsComponents/units/template/form/comments/comments.types";
-import { AdminCommentsInitType } from "../../../admin.comments.types";
+import { FetchCommentsTypes } from "../../../admin.comments.types";
 import { WriteInfoTypes } from "src/main/commonsComponents/units/template/form/comments/write/comments.write.types";
 
 import { checkAccessToken } from "src/main/commonsComponents/withAuth/check";
@@ -25,10 +24,9 @@ export default function AdminCommentsContentsPage({
 }: {
   info: InfoTypes;
   changeLoading: (bool: boolean) => void;
-  commentsInfo: CommentsAllInfoTypes & AdminCommentsInitType;
-  fetchComments: (info?: AdminCommentsInitType) => void;
+  commentsInfo: CommentsAllInfoTypes;
   isAlreadyDeleted: boolean;
-}) {
+} & FetchCommentsTypes) {
   let answer = "";
   let bugStatus = info.bugStatus || 0;
   // 기존의 답변 저장
@@ -70,7 +68,7 @@ export default function AdminCommentsContentsPage({
       const updateResult = await (
         await commentsApis({
           module: commentsInfo.selectModule,
-          input: _info,
+          ip: info.ip,
           isAdmin: true,
         })
       ).modifyComments({
@@ -87,7 +85,7 @@ export default function AdminCommentsContentsPage({
           textRef.current.focus();
       } else {
         // 업데이트에 성공한 경우
-        fetchComments(commentsInfo);
+        fetchComments({ info: commentsInfo });
         alert("답변이 업데이트 되었습니다.");
       }
     } catch (err) {


### PR DESCRIPTION
1. 관리자 댓글 페이지 내에 유저 페이지와 동일하게 댓글을 필터할 수 있는 필터 기능 추가 완료
2. 추가로 관리자 댓글 페이지 내에서만 "삭제된 댓글 보기" 필터가 새롭게 추가됨
3. 삭제된 댓글을 조회할 수 있도록 기존 count DB의 각각의 카테고리 안에 삭제된 댓글의 개수를 카운트할 수 있도록 "deleted" 컬럼 새로 추가
4. 댓글을 삭제하는 api를 작동시킬 때마다 count DB의 deleted 값을 1개씩 추가하도록 기능 설정
5. 필터 작동시 "과거순 보기"와 "삭제된 댓글 보기"는 공통 필터로 구분하여, 카테고리를 변경해도 그대로 유지되도록 변경