### PR TITLE
2023-08-04 :: 댓글 필터별 적용된 개수 동기화 작업 완료

### DIFF
--- a/src/commons/libraries/apis/comments/count/count.apis.ts
+++ b/src/commons/libraries/apis/comments/count/count.apis.ts
@@ -267,6 +267,10 @@ const countApis = ({ module }: { module: string }) => {
                   filterCountList[category].count =
                     categoryInfo["question-complete"];
 
+                  // 삭제된 개수를 "삭제된 완료된 댓글" 수로 변경하기
+                  filterCountList.question.deleted =
+                    categoryInfo["question-complete-deleted"];
+
                   if (deleted)
                     // 삭제된 댓글도 포함이라면 삭제된 완료된 댓글도 포함하기
                     filterCountList[category].count +=
@@ -317,9 +321,13 @@ const countApis = ({ module }: { module: string }) => {
                           // 선택한 필터의 개수만큼 전체 개수에 더하기
                           allCount += categoryInfo[`${category}-${num}`];
 
-                          if (deleted)
+                          if (deleted) {
                             allCount +=
                               categoryInfo[`${category}-${num}-deleted`];
+
+                            // 각각의 필터 점수에도 삭제된 내역의 수만큼 더하기
+                            console.log(categoryInfo);
+                          }
                         }
                       }
                     }

--- a/src/commons/libraries/apis/comments/count/count.apis.ts
+++ b/src/commons/libraries/apis/comments/count/count.apis.ts
@@ -281,6 +281,7 @@ const countApis = ({ module }: { module: string }) => {
 
                 // 이슈 및 리뷰는 모든 필터 리스트로 개수 종합
                 let allCount = categoryInfo.count;
+
                 //  삭제 보기일 땐 삭제된 개수도 포함하기
                 if (deleted) allCount += categoryInfo.deleted;
 
@@ -304,35 +305,53 @@ const countApis = ({ module }: { module: string }) => {
                 if (hasFilter) {
                   // 필터가 있다면 0으로 초기화
                   allCount = 0;
+                  filterCountList[category].deleted = 0;
+                  filterCountList.bug["bug-complete"] = 0;
+                }
 
-                  Array.from(new Array(5), (_, idx) => 1 + idx).forEach(
-                    (num) => {
-                      if (list[`${category}-${num}`]) {
-                        if (category === "bug" && list["bug-complete"]) {
-                          // 카테고리가 버그이고, "해결 완료만 보기" 필터가 적용되어 있을 경우
-                          // 해결 완료된 해당 점수의 개수만 더한다.
-                          allCount += categoryInfo[`bug-${num}-complete`];
+                Array.from(new Array(5), (_, idx) => 1 + idx).forEach((num) => {
+                  // 해결 완료된 것만 보기 = 이슈 필터의 개수에서 해결 완료된 갯수로 저장
+                  if (category === "bug" && list["bug-complete"]) {
+                    // 각각의 필터 개수는 해결 완료된 갯수로 저장한다.
+                    filterCountList[category][`bug-${num}`] =
+                      filterCountList[category][`bug-${num}-complete`];
+                  }
 
-                          if (deleted)
-                            // 만약 삭제까지 포함된다면, 해결 완료된 댓글 중 삭제된 개수까지 더한다.
-                            allCount +=
-                              categoryInfo[`bug-${num}-complete-deleted`];
-                        } else {
-                          // 선택한 필터의 개수만큼 전체 개수에 더하기
-                          allCount += categoryInfo[`${category}-${num}`];
+                  if (list[`${category}-${num}`]) {
+                    if (category === "bug" && list["bug-complete"]) {
+                      // 카테고리가 버그이고, "해결 완료만 보기" 필터가 적용되어 있을 경우
+                      // 해결 완료된 해당 점수의 개수만 더한다.
+                      allCount += categoryInfo[`bug-${num}-complete`];
 
-                          if (deleted) {
-                            allCount +=
-                              categoryInfo[`${category}-${num}-deleted`];
+                      // 선택된 버그 카테고리 개수에서 해결 완료된 개수 종합하기
+                      filterCountList.bug["bug-complete"] +=
+                        categoryInfo[`bug-${num}-complete`];
 
-                            // 각각의 필터 점수에도 삭제된 내역의 수만큼 더하기
-                            console.log(categoryInfo);
-                          }
-                        }
+                      if (deleted)
+                        // 만약 삭제까지 포함된다면, 해결 완료된 댓글 중 삭제된 개수까지 더한다.
+                        allCount += categoryInfo[`bug-${num}-complete-deleted`];
+                    } else {
+                      // 선택한 필터의 개수만큼 전체 개수에 더하기
+                      allCount += categoryInfo[`${category}-${num}`];
+                      filterCountList[category].deleted +=
+                        categoryInfo[`${category}-${num}-deleted`];
+
+                      // 이슈 카테고리의 "해결 완료만 보기" 개수 종합하기
+                      filterCountList.bug["bug-complete"] +=
+                        categoryInfo[`bug-${num}-complete`];
+
+                      if (deleted) {
+                        allCount += categoryInfo[`${category}-${num}-deleted`];
                       }
                     }
-                  );
-                }
+                  }
+
+                  if (deleted) {
+                    // 삭제된 내역만 보기 선택시, 각각의 필터 개수 동기화하기
+                    filterCountList[category][`${category}-${num}`] +=
+                      filterCountList[category][`${category}-${num}-deleted`];
+                  }
+                });
                 filterCountList[category].count = allCount;
               }
             });

--- a/src/main/commonsComponents/units/template/form/comments/list/filter/filter.init.ts
+++ b/src/main/commonsComponents/units/template/form/comments/list/filter/filter.init.ts
@@ -20,16 +20,14 @@ export const filterInitList: Array<InitTypes> = [
 // 카테고리별 추가 필터 리스트
 export const categoryFilterList: { [key: string]: Array<InitTypes> } = {
   bug: [
-    [{ name: "해결 완료만 보기", target: "bug-complete", isHide: true }],
+    [{ name: "해결 완료만 보기", target: "bug-complete" }],
     Array.from(new Array(5), (_, i) => 1 + i)
       .reverse()
       .map((el) => {
         return { name: `중요도 ${el}점 보기`, target: `bug-${el}` };
       }),
   ].flat(),
-  question: [
-    { name: "답변 완료만 보기", target: "question-complete", isHide: true },
-  ],
+  question: [{ name: "답변 완료만 보기", target: "question-complete" }],
   review: Array.from(new Array(5), (_, i) => 1 + i)
     .reverse()
     .map((el) => {

--- a/src/main/commonsComponents/units/template/form/comments/list/filter/index.tsx
+++ b/src/main/commonsComponents/units/template/form/comments/list/filter/index.tsx
@@ -117,6 +117,7 @@ export default function CommentsFilterPage({
     waiting = true;
 
     const _commentsInfo = { ...commentsInfo };
+    // 해당 필터 적용하기
     _commentsInfo.filter.list[info.target] =
       _commentsInfo.filter.list[info.target] !== undefined
         ? !_commentsInfo.filter.list[info.target]
@@ -173,8 +174,11 @@ export default function CommentsFilterPage({
             const count = countFilterList[selectCategory][el.target] || "";
 
             // 필터의 개수가 0개인지 검증
-            let isEmpty = count === 0 || (count === "" && !el.searchFilterList);
-            if (isAdmin && filter.list.deleted) {
+            let isEmpty = count === 0 || count === "";
+            if (el.target === "oddest") isEmpty = false;
+
+            // 갯수가 0이지만 이미 선택되어 있는 경우
+            if (isEmpty && isSelected) {
               isEmpty = false;
             }
 


### PR DESCRIPTION
1. 댓글 필터에서 선택된 필터에 따라 각각의 필터 개수 자동 동기화 작업 완료
  - 예를들어, 이슈 카테고리에서 전체 댓글 수가 10개이고, 완료된 댓글 보기가 5개이며, 1점 보기가 3개가 있다고 가정했을 때
     "1점 보기" 필터를 선택하면 자동으로 1점 보기에서 완료된 댓글의 수를 카운트해 완료된 댓글 보기의 개수에 반영이 됨